### PR TITLE
Load datasets into a temporary schema, then into the public schema.

### DIFF
--- a/dbshell.py
+++ b/dbshell.py
@@ -1,6 +1,7 @@
-import subprocess
-from load_dataset import NYCDB_CMD
+from nycdb.cli import run_dbshell
+
+from load_dataset import NYCDB_ARGS
 
 
 if __name__ == '__main__':
-    subprocess.call(NYCDB_CMD + ['--dbshell'])
+    run_dbshell(NYCDB_ARGS)

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -89,6 +89,9 @@ def create_and_enter_temporary_schema(conn, schema: str):
 
     try:
         yield
+    except Exception as e:
+        conn.rollback()
+        raise e
     finally:
         with conn.cursor() as cur:
             cur.execute('; '.join([

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -76,6 +76,7 @@ def drop_tables_if_they_exist(conn, tables: List[TableInfo], schema: str):
 
 @contextlib.contextmanager
 def create_and_enter_temporary_schema(conn, schema: str):
+    print(f"Creating and entering temporary schema '{schema}'.")
     with conn.cursor() as cur:
          cur.execute('; '.join([
              f"DROP SCHEMA IF EXISTS {schema} CASCADE",
@@ -93,6 +94,7 @@ def create_and_enter_temporary_schema(conn, schema: str):
         conn.rollback()
         raise e
     finally:
+        print(f"Destroying temporary schema '{schema}'.")
         with conn.cursor() as cur:
             cur.execute('; '.join([
                 f'DROP SCHEMA {schema} CASCADE',

--- a/slack.py
+++ b/slack.py
@@ -70,6 +70,7 @@ def sendmsg(text: str, is_safe=False) -> bool:
     Returns True if the message was successfully sent, False otherwise.
     '''
 
+    print(text)
     if not is_safe:
         text = escape(text)
     return send_payload({'text': text})


### PR DESCRIPTION
This supersedes #1. following the same advice given in https://github.com/aepyornis/nyc-db/issues/53#issuecomment-447079460.  I just found it easier to start anew given all the changes in the codebase that happened since #1 was filed.

## Notes

* We add a timestamp to the name of the temporary schema for two reasons: to make it easy to understand when the temporary schema was created, and to ensure that if multiple loading processes for the same dataset happen to overlap, they don't clobber each other's temporary schemas.

* `show_rowcounts.py` has been enhanced to show both the rowcounts of a dataset's public schema, as well as any temporary schemas that may exist.  This has a bonus side effect of giving us some idea of how close a loading process might be to completion, assuming the public schema is already populated with real data.
