### PR TITLE
Send slack message on exceptions.

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -172,22 +172,7 @@ def sanity_check():
     assert TEST_DATA_DIR.exists()
 
 
-def main():
-    sanity_check()
-
-    NYCDB_DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-    tables = get_dataset_tables()
-
-    dataset = DATASET
-
-    if not dataset:
-        if len(sys.argv) <= 1:
-            print(f"Usage: {sys.argv[0]} <dataset>")
-            print(f"Alternatively, set the DATASET environment variable.")
-            sys.exit(1)
-        dataset = sys.argv[1]
-
+def load_dataset(dataset: str):
     tables = get_tables_for_dataset(dataset)
     ds = Dataset(dataset, args=NYCDB_ARGS)
 
@@ -205,6 +190,29 @@ def main():
             change_table_schemas(conn, tables, temp_schema, 'public')
     slack.sendmsg(f'Finished loading the dataset `{dataset}` into the database.')
     print("Success!")
+
+
+def main():
+    sanity_check()
+
+    NYCDB_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    tables = get_dataset_tables()
+
+    dataset = DATASET
+
+    if not dataset:
+        if len(sys.argv) <= 1:
+            print(f"Usage: {sys.argv[0]} <dataset>")
+            print(f"Alternatively, set the DATASET environment variable.")
+            sys.exit(1)
+        dataset = sys.argv[1]
+
+    try:
+        load_dataset(dataset)
+    except Exception as e:
+        slack.sendmsg(f"Alas, an error occurred when loading the dataset `{dataset}`.")
+        raise e
 
 
 if __name__ == '__main__':

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -192,7 +192,7 @@ def load_dataset(dataset: str):
     print("Success!")
 
 
-def main():
+def main(argv: List[str]=sys.argv):
     sanity_check()
 
     NYCDB_DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -201,12 +201,13 @@ def main():
 
     dataset = DATASET
 
+    if len(argv) > 1:
+        dataset = argv[1]
+
     if not dataset:
-        if len(sys.argv) <= 1:
-            print(f"Usage: {sys.argv[0]} <dataset>")
-            print(f"Alternatively, set the DATASET environment variable.")
-            sys.exit(1)
-        dataset = sys.argv[1]
+        print(f"Usage: {argv[0]} <dataset>")
+        print(f"Alternatively, set the DATASET environment variable.")
+        sys.exit(1)
 
     try:
         load_dataset(dataset)

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -89,3 +89,8 @@ def test_get_temp_schemas_works(test_db_env, conn):
                 'temp_boop_1234'
             ]
         assert len(load_dataset.get_temp_schemas(conn, 'boop')) == 0
+
+
+def test_exceptions_send_slack_msg():
+    # TODO: Finish this.
+    pass

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -92,5 +92,12 @@ def test_get_temp_schemas_works(test_db_env, conn):
 
 
 def test_exceptions_send_slack_msg():
-    # TODO: Finish this.
-    pass
+    with patch.object(load_dataset, 'load_dataset') as load:
+        with patch.object(load_dataset.slack, 'sendmsg') as sendmsg:
+            load.side_effect = Exception('blah')
+            with pytest.raises(Exception, match='blah'):
+                load_dataset.main(['', 'hpd_registrations'])
+            load.assert_called_once_with('hpd_registrations')
+            sendmsg.assert_called_once_with(
+                'Alas, an error occurred when loading the dataset `hpd_registrations`.'
+            )


### PR DESCRIPTION
Fixes #6.

This also changes the behavior of the `load_dataset.py` tool by having CLI options override environment variables instead of the other way around.

## To do

- [x] Add test case.
