### PR TITLE
Only download and load a dataset if it has changed

### DIFF
--- a/dbhash.py
+++ b/dbhash.py
@@ -33,7 +33,9 @@ class AbstractDbHash(abc.ABC):
 
 
 class DictDbHash(AbstractDbHash):
-    def __init__(self, d: Dict[str, str]):
+    def __init__(self, d: Optional[Dict[str, str]]=None):
+        if d is None:
+            d = {}
         self.d = d
 
     def get(self, key: str) -> Optional[str]:

--- a/dbhash.py
+++ b/dbhash.py
@@ -1,0 +1,100 @@
+import abc
+from typing import Optional, Iterable, Any, Dict
+from sqlite3 import Connection, Cursor
+
+
+class AbstractDbHash(abc.ABC):
+    @abc.abstractmethod
+    def get(self, key: str) -> Optional[str]:
+        ...
+
+    @abc.abstractmethod
+    def __setitem__(self, key: str, value: str) -> None:
+        ...
+
+    @abc.abstractmethod
+    def __delitem__(self, key: str) -> None:
+        ...
+
+    def __getitem__(self, key: str) -> str:
+        item = self.get(key)
+        if item is None:
+            raise KeyError(key)
+        return item
+
+    def __contains__(self, key: str) -> bool:
+        return self.get(key) is not None
+
+    def set_or_delete(self, key: str, value: Optional[str]) -> None:
+        if value is not None:
+            self[key] = value
+        elif key in self:
+            del self[key]
+
+
+class DictDbHash(AbstractDbHash):
+    def __init__(self, d: Dict[str, str]):
+        self.d = d
+
+    def get(self, key: str) -> Optional[str]:
+        return self.d.get(key)
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.d[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.d[key]
+
+
+class SqlDbHash(AbstractDbHash):
+    PARAM_SUBST_STRINGS: Dict[str, str] = {
+        'sqlite3': r'?',
+        'psycopg2.extensions': r'%s'
+    }
+
+    def __init__(self, conn: Connection, table: str, autocommit: bool=True):
+        self.table = table
+        self.param_subst = self.__class__.PARAM_SUBST_STRINGS[conn.__class__.__module__]
+        self.autocommit = autocommit
+        self.conn = conn
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self._exec_sql(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.table} (
+                key text PRIMARY KEY NOT NULL,
+                value text NOT NULL
+            )
+            """
+        )
+
+    def _exec_sql(self, sql: str, params: Iterable[Any]=tuple()) -> Cursor:
+        sql = sql.replace('?', self.param_subst)
+        cur = self.conn.cursor()
+        cur.execute(sql, params)
+        return cur
+
+    def __setitem__(self, key: str, value: str) -> None:
+        if self.get(key) is not None:
+            self._exec_sql(f"UPDATE {self.table} SET value = ? WHERE key = ?",
+                           (value, key))
+        else:
+            self._exec_sql(
+                f"INSERT INTO {self.table} (key, value) VALUES (?, ?)", (key, value))
+        if self.autocommit:
+            self.conn.commit()
+
+    def __delitem__(self, key: str) -> None:
+        if key not in self:
+            raise KeyError(key)
+        self._exec_sql(
+            f"DELETE FROM {self.table} WHERE key = ?", (key,))
+        if self.autocommit:
+            self.conn.commit()
+
+    def get(self, key: str) -> Optional[str]:
+        cur = self._exec_sql(
+            f"SELECT value FROM {self.table} WHERE key = ?", (key,))
+        result = cur.fetchone()
+        return None if result is None else result[0]

--- a/dbshell.py
+++ b/dbshell.py
@@ -1,7 +1,7 @@
 from nycdb.cli import run_dbshell
 
-from load_dataset import NYCDB_ARGS
+from load_dataset import Config
 
 
 if __name__ == '__main__':
-    run_dbshell(NYCDB_ARGS)
+    run_dbshell(Config().nycdb_args)

--- a/lastmod.py
+++ b/lastmod.py
@@ -49,6 +49,7 @@ class UrlModTracker:
     def did_any_urls_change(self) -> bool:
         self.updated_lastmods = []
         for url in self.urls:
+            print(f"Checking {url}...")
             lminfo = LastmodInfo.read_from_dbhash(url, self.dbhash)
             res = requests.get(url, headers=lminfo.to_request_headers(), stream=True)
             if res.status_code == 200:

--- a/lastmod.py
+++ b/lastmod.py
@@ -1,0 +1,67 @@
+from typing import Optional, NamedTuple, TypeVar, Type, Dict, List
+import requests
+
+from dbhash import AbstractDbHash
+
+
+T = TypeVar('T', bound='LastmodInfo')
+
+
+class LastmodInfo(NamedTuple):
+    url: str
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None
+
+    @classmethod
+    def read_from_dbhash(cls: Type[T], url: str, dbhash: AbstractDbHash) -> T:
+        return cls(
+            url=url,
+            etag=dbhash.get(f'etag:{url}'),
+            last_modified=dbhash.get(f'last_modified:{url}')
+        )
+
+    def write_to_dbhash(self, dbhash: AbstractDbHash) -> None:
+        dbhash.set_or_delete(f'last_modified:{self.url}', self.last_modified)
+        dbhash.set_or_delete(f'etag:{self.url}', self.etag)
+
+    @classmethod
+    def from_response_headers(cls: Type[T], url: str, headers: Dict[str, str]) -> T:
+        return cls(
+            url=url,
+            etag=headers.get('ETag'),
+            last_modified=headers.get('Last-Modified')
+        )
+
+    def to_request_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self.etag:
+            headers['If-None-Match'] = self.etag
+        if self.last_modified:
+            headers['If-Modified-Since'] = self.last_modified
+        return headers
+
+
+class UrlModTracker:
+    updated_lastmods: List[LastmodInfo]
+
+    def __init__(self, urls: List[str], dbhash: AbstractDbHash):
+        self.urls = urls
+        self.dbhash = AbstractDbHash
+        self.updated_lastmods = []
+
+    def did_any_urls_change(self) -> bool:
+        self.updated_lastmods = []
+        for url in self.urls:
+            lminfo = LastmodInfo.read_from_dbhash(url, self.dbhash)
+            res = requests.get(url, headers=lminfo.to_request_headers(), stream=True)
+            if res.status_code == 200:
+                self.updated_lastmods.append(
+                    LastmodInfo.from_response_headers(url, res.headers))
+            elif res.status_code != 304:
+                res.raise_for_status()
+            res.close()
+        return len(self.updated_lastmods) > 0
+
+    def update_lastmods(self) -> None:
+        for lminfo in self.update_lastmods:
+            lminfo.write_to_dbhash(self.dbhash)

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -90,6 +90,12 @@ def get_tables_for_dataset(dataset: str) -> List[TableInfo]:
     return tables
 
 
+def get_urls_for_dataset(dataset: str) -> List[str]:
+    return [
+        fileinfo['url'] for fileinfo in nycdb.dataset.datasets()[dataset]['files']
+    ]
+
+
 def drop_tables_if_they_exist(conn, tables: List[TableInfo], schema: str):
     with conn.cursor() as cur:
         for table in tables:
@@ -174,6 +180,7 @@ def sanity_check():
 
 def load_dataset(dataset: str):
     tables = get_tables_for_dataset(dataset)
+    urls = get_urls_for_dataset(dataset)
     ds = Dataset(dataset, args=NYCDB_ARGS)
 
     slack.sendmsg(f'Downloading the dataset `{dataset}`...')

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,4 @@ requests-mock
 boto3
 docopt
 python-dotenv
+requests-mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import time
 import urllib.parse
+from unittest.mock import patch
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import pytest
@@ -81,3 +82,12 @@ def conn(db):
 
 def make_conn():
     return psycopg2.connect(DATABASE_URL)
+
+
+@pytest.fixture()
+def slack_outbox():
+    slack_outbox = []
+    log_slack_msg = lambda x: slack_outbox.append(x)
+
+    with patch('slack.sendmsg', side_effect=log_slack_msg):
+        yield slack_outbox

--- a/tests/test_dbhash.py
+++ b/tests/test_dbhash.py
@@ -50,8 +50,12 @@ def test_sqlite_sqldbhash():
     dbfile.unlink()
 
 
-def test_dictdbhash():
+def test_dictdbhash_impl():
     _test_dbhash_implementation(DictDbHash({}))
+
+
+def test_dictdbhash_defaults_to_empty_dict():
+    assert DictDbHash().d == {}
 
 
 def test_postgres_sqldbhash(conn):

--- a/tests/test_dbhash.py
+++ b/tests/test_dbhash.py
@@ -1,0 +1,60 @@
+import pytest
+
+from dbhash import AbstractDbHash, DictDbHash, SqlDbHash
+
+
+def _test_dbhash_implementation(dbh: AbstractDbHash):
+    with pytest.raises(KeyError):
+        dbh['foo']
+
+    with pytest.raises(KeyError):
+        del dbh['foo']
+
+    assert 'foo' not in dbh
+    assert dbh.get('foo') is None
+
+    dbh['foo'] = 'bar'
+    assert 'foo' in dbh
+    assert dbh['foo'] == 'bar'
+    assert dbh.get('foo') == 'bar'
+
+    dbh['foo'] = 'baz'
+    assert 'foo' in dbh
+    assert dbh['foo'] == 'baz'
+    assert dbh.get('foo') == 'baz'
+
+    del dbh['foo']
+    assert 'foo' not in dbh
+
+    dbh.set_or_delete('foo', None)
+    assert 'foo' not in dbh
+    dbh.set_or_delete('foo', 'quux')
+    assert dbh['foo'] == 'quux'
+    dbh.set_or_delete('foo', None)
+    assert 'foo' not in dbh
+
+
+def test_sqlite_sqldbhash():
+    from pathlib import Path
+    import sqlite3
+
+    dbfile = Path('test_sqlite_sqldbhash.db')
+    if dbfile.exists():
+        dbfile.unlink()
+    conn = sqlite3.connect(str(dbfile))
+    dbh = SqlDbHash(conn, 'blarg')
+
+    _test_dbhash_implementation(dbh)
+
+    conn.close()
+    dbfile.unlink()
+
+
+def test_dictdbhash():
+    _test_dbhash_implementation(DictDbHash({}))
+
+
+def test_postgres_sqldbhash(conn):
+    dbh = SqlDbHash(conn, 'blarg')
+
+    _test_dbhash_implementation(dbh)

--- a/tests/test_lastmod.py
+++ b/tests/test_lastmod.py
@@ -1,0 +1,40 @@
+from lastmod import LastmodInfo
+from dbhash import DictDbHash
+
+
+class TestLastmodInfo:
+    def test_read_from_dbhash_works(self):
+        dbh = DictDbHash({
+            'etag:http://boop': 'blah',
+            'last_modified:http://boop': 'flarg'
+        })
+        assert LastmodInfo.read_from_dbhash('http://boop', dbh) == LastmodInfo(
+            url="http://boop", etag="blah", last_modified="flarg")
+        
+        assert LastmodInfo.read_from_dbhash('http://bar', dbh) == LastmodInfo(
+            "http://bar", None, None)
+
+    def test_write_to_dbhash_works(self):
+        dbh = DictDbHash()
+        LastmodInfo('http://boop', 'blah', 'flarg').write_to_dbhash(dbh)
+        assert dbh.d == {
+            'etag:http://boop': 'blah',
+            'last_modified:http://boop': 'flarg'
+        }
+
+        LastmodInfo('http://boop').write_to_dbhash(dbh)
+        assert dbh.d == {}
+
+
+    def test_from_response_headers_works(self):
+        assert LastmodInfo.from_response_headers('http://boop', {
+            'ETag': 'blah',
+            'Last-Modified': 'flarg'
+        }) == LastmodInfo('http://boop', 'blah', 'flarg')
+
+
+    def test_to_request_headers_works(self):
+        assert LastmodInfo('http://boop', 'blah', 'flarg').to_request_headers() == {
+            'If-None-Match': 'blah',
+            'If-Modified-Since': 'flarg'
+        }

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -34,6 +34,13 @@ def get_row_counts(conn, dataset: str) -> Dict[str, int]:
     return dict(show_rowcounts.get_rowcounts(conn, tables))
 
 
+def test_get_urls_for_dataset_works():
+    urls = load_dataset.get_urls_for_dataset('hpd_registrations')
+    assert len(urls) > 0
+    for url in urls:
+        assert url.startswith('https://')
+
+
 @pytest.mark.parametrize('dataset', nycdb.dataset.datasets().keys())
 def test_load_dataset_works(test_db_env, dataset):
     with make_conn() as conn:

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -98,13 +98,38 @@ def test_get_temp_schemas_works(test_db_env, conn):
         assert len(load_dataset.get_temp_schemas(conn, 'boop')) == 0
 
 
-def test_exceptions_send_slack_msg():
+def test_exceptions_send_slack_msg(slack_outbox):
     with patch.object(load_dataset, 'load_dataset') as load:
-        with patch.object(load_dataset.slack, 'sendmsg') as sendmsg:
-            load.side_effect = Exception('blah')
-            with pytest.raises(Exception, match='blah'):
-                load_dataset.main(['', 'hpd_registrations'])
-            load.assert_called_once_with('hpd_registrations')
-            sendmsg.assert_called_once_with(
-                'Alas, an error occurred when loading the dataset `hpd_registrations`.'
-            )
+        load.side_effect = Exception('blah')
+        with pytest.raises(Exception, match='blah'):
+            load_dataset.main(['', 'hpd_registrations'])
+        load.assert_called_once_with('hpd_registrations')
+        assert slack_outbox == [
+            'Alas, an error occurred when loading the dataset `hpd_registrations`.'
+        ]
+
+
+def test_unmodified_datasets_are_not_retrieved(db, requests_mock, slack_outbox):
+    urls = load_dataset.get_urls_for_dataset('hpd_registrations')
+    config = load_dataset.Config(database_url=DATABASE_URL, use_test_data=True)
+    load = lambda: load_dataset.load_dataset('hpd_registrations', config, force_check_urls=True)
+
+    for url in urls:
+        requests_mock.get(url, text='blah', headers={'ETag': 'blah'})
+
+    load()
+    assert slack_outbox[0] == 'Downloading the dataset `hpd_registrations`...'
+    slack_outbox[:] = []
+
+    for url in urls:
+        requests_mock.get(url, request_headers={'If-None-Match': 'blah'}, status_code=304)
+    load()
+    assert slack_outbox == [
+        'The dataset `hpd_registrations` has not changed since we last retrieved it.'
+    ]
+    slack_outbox[:] = []
+
+    for url in urls:
+        requests_mock.get(url, text='blah2', headers={'ETag': 'blah2'})
+    load()
+    assert slack_outbox[0] == 'Downloading the dataset `hpd_registrations`...'


### PR DESCRIPTION
This adds a mechanism to ensure that we only download and load a dataset if the server says it has been modified since we last downloaded it.

With this in place, we can trigger even the monthly and yearly jobs on a daily basis, ensuring that they are updated as soon as a new version of the dataset is made available (it appears many of these datasets are not updated on a fixed schedule, so this would be useful), without incurring many unnecessary hours of compute time.

## To do

- [x] Add more tests.
