### PR TITLE
Support derived tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk update && \
   rm -rf /var/cache/apk/*
 
 ARG NYCDB_REPO=https://github.com/aepyornis/nyc-db
-ARG NYCDB_REV=ac5f13cc80662efb3debd8d4514a6a7a99d4e05f
+ARG NYCDB_REV=6e95f7884578670dac8207819ef37d217dbbd540
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -15,6 +15,7 @@ from nycdb.utility import list_wrap
 
 import slack
 import db_perms
+from parse_created_tables import parse_nycdb_created_tables
 from lastmod import UrlModTracker
 from dbhash import SqlDbHash
 
@@ -78,8 +79,12 @@ def get_temp_schemas(conn, dataset: str) -> List[str]:
 def get_dataset_tables() -> List[TableInfo]:
     result: List[TableInfo] = []
     for dataset_name, info in nycdb.dataset.datasets().items():
-         for schema in list_wrap(info['schema']):
+        for schema in list_wrap(info['schema']):
             result.append(TableInfo(name=schema['table_name'], dataset=dataset_name))
+        result.extend([
+            TableInfo(name=name, dataset=dataset_name)
+            for name in parse_nycdb_created_tables(info.get('sql', []))
+        ])
     return result
 
 

--- a/parse_created_tables.py
+++ b/parse_created_tables.py
@@ -1,0 +1,41 @@
+from typing import List
+from pathlib import Path
+from functools import lru_cache
+import sqlparse
+from sqlparse.sql import Identifier
+from sqlparse import tokens as T
+import nycdb
+
+
+NYCDB_SQL_DIR = Path(nycdb.__file__).parent.resolve() / 'sql'
+
+
+def parse_created_tables(sql: str) -> List[str]:
+    tables: List[str] = []
+
+    for stmt in sqlparse.parse(sql):
+        print(stmt.tokens)
+        identifiers = [
+            str(token.tokens[0]) for token in stmt.tokens
+            if isinstance(token, Identifier)
+        ]
+        keywords = [
+            str(token).upper() for token in stmt.tokens
+            if token.is_keyword
+        ]
+        if keywords[:2] == ['CREATE', 'TABLE'] and identifiers:
+            tables.append(identifiers[0])
+
+    return tables
+
+
+@lru_cache()
+def _parse_nycdb_sql_file(filename: str) -> List[str]:
+    return parse_created_tables((NYCDB_SQL_DIR / filename).read_text())
+
+
+def parse_nycdb_created_tables(filenames: List[str]) -> List[str]:
+    result: List[str] = []
+    for filename in filenames:
+        result.extend(_parse_nycdb_sql_file(filename))
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests==2.21.0
 tqdm==4.28.1
 urllib3==1.24.1
 xlrd==1.2.0
+sqlparse==0.2.4

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -22,6 +22,14 @@ def test_db_env(db):
     yield env
 
 
+def test_get_dataset_tables_included_derived_tables():
+    info = load_dataset.TableInfo(
+        name='hpd_registrations_grouped_by_bbl',
+        dataset='hpd_registrations'
+    )
+    assert info in load_dataset.get_dataset_tables()
+
+
 def drop_dataset_tables(conn, dataset: str, ok_if_nonexistent: bool):
     with conn.cursor() as cur:
         for table in load_dataset.get_tables_for_dataset(dataset):

--- a/tests/test_parse_created_tables.py
+++ b/tests/test_parse_created_tables.py
@@ -1,0 +1,45 @@
+from parse_created_tables import (
+    parse_created_tables,
+    parse_nycdb_created_tables
+)
+
+
+def test_it_returns_empty_list_when_no_tables_are_created():
+    assert parse_created_tables(
+        "ALTER TABLE hpd_registrations ADD COLUMN bbl char(10);"
+    ) == []
+
+
+def test_it_parses_create_table_statements():
+    sql = """\
+    DROP TABLE IF EXISTS blarg;
+
+    CREATE TABLE blarg
+    as SELECT
+    first(floof) as floof,
+    FROM goopy
+    GROUP BY bbl, jibjab;
+
+    create index on blarg (floof);
+    """
+
+    assert parse_created_tables(sql) == ['blarg']
+    assert parse_created_tables(sql.lower()) == ['blarg']
+    assert parse_created_tables(sql.upper()) == ['BLARG']
+
+
+def test_it_parses_create_table_statements_2():
+    sql = """\
+    CREATE TABLE  foo AS (
+       SELECT BusinessHouseNumber,
+       blah
+       FROM thing
+       WHERE boop IS NOT NULL;
+    """
+
+    assert parse_created_tables(sql) == ['foo']
+
+
+def test_it_parses_nycdb_files():
+    assert 'hpd_registrations_grouped_by_bbl' in parse_nycdb_created_tables([
+        'hpd_registrations/registrations_grouped_by_bbl.sql'])


### PR DESCRIPTION
This fixes #13 in a sort of funky way: by parsing the SQL files for dataset transformations via [`sqlparse`](https://sqlparse.readthedocs.io/) and using a bit of static analysis to figure out what tables are being created.

Another approach would be to simply list all the tables in the temporary schema after executing the transformations, but there were a number of places `get_dataset_tables` were being used, and some of them might not have assumed that they have a live postgres instance to query. Also, I always wanted to play around with SQL parsing.

Anyways, if this ends up not working out in the long run we can always revert it.

This also updates our version of NYCDB to https://github.com/aepyornis/nyc-db/commit/6e95f7884578670dac8207819ef37d217dbbd540.