### PR TITLE
Add support for generating Who Owns What tables and functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nyc-db.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=9034b0baca599c612dc6b102680108c80697dd44
+ARG WOW_REV=cae0b6de35eba25df3376f6e890312aa55356c98
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,13 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nyc-db.zip \
   && cd nyc-db/src \
   && pip install -e .
 
+ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
+ARG WOW_REV=9034b0baca599c612dc6b102680108c80697dd44
+RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
+  && unzip wow.zip \
+  && rm wow.zip \
+  && mv who-owns-what-${WOW_REV} who-owns-what
+
 COPY . /app
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -202,6 +202,27 @@ Our continuous integration system will then ensure that everything still
 works, and once the PR is merged into `master`, Docker Hub will re-publish
 a new container image that uses the latest version of NYC-DB.
 
+## Updating Who Owns What data
+
+This repository also contains `wowutil.py`, a tool for creating and
+updating the NYCDB-derived tables and functions required by
+[Who Owns What][] (WoW).
+
+Currently, the tool creates WoW's tables and functions under a
+Postgres schema called `wow`.  It's the responsibility of the
+database administrator to set the [Postgres schema search path][]
+to `wow, public` for WoW's functions to work properly.
+
+Unlike the NYCDB datasets, at the time of this writing, there are
+no tools to automate the *scheduling* of WoW data updates.
+
+It is also your responsibility to ensure that the NYCDB dependencies
+of the WoW data are already in the database at the time that
+`wowutil.py` is used to generate the WoW tables and functions.
+
+The specific version of WoW used by `wowutil.py` is specified
+by the `WOW_REV` argument in the `Dockerfile`.
+
 [Cron Jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 [NYC-DB]: https://github.com/aepyornis/nyc-db
 [Kubernetes Jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
@@ -213,3 +234,5 @@ a new container image that uses the latest version of NYC-DB.
 [Scheduled Tasks]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduled_tasks.html
 [rev]: https://github.com/JustFixNYC/nycdb-k8s-loader/blob/master/Dockerfile#L19
 [Postgres schema]: https://www.postgresql.org/docs/9.5/ddl-schemas.html
+[Who Owns What]: https://github.com/justfixnyc/who-owns-what
+[Postgres schema search path]: https://www.postgresql.org/docs/9.6/ddl-schemas.html#DDL-SCHEMAS-PATH

--- a/lib/parse_created_tables.py
+++ b/lib/parse_created_tables.py
@@ -28,12 +28,16 @@ def parse_created_tables(sql: str) -> List[str]:
 
 
 @lru_cache()
-def _parse_nycdb_sql_file(filename: str) -> List[str]:
-    return parse_created_tables((NYCDB_SQL_DIR / filename).read_text())
+def _parse_sql_file(path: Path) -> List[str]:
+    return parse_created_tables(path.read_text())
 
 
 def parse_nycdb_created_tables(filenames: List[str]) -> List[str]:
+    return parse_created_tables_in_dir(NYCDB_SQL_DIR, filenames)
+
+
+def parse_created_tables_in_dir(root_dir: Path, filenames: List[str]) -> List[str]:
     result: List[str] = []
     for filename in filenames:
-        result.extend(_parse_nycdb_sql_file(filename))
+        result.extend(_parse_sql_file(root_dir / filename))
     return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,13 @@ def create_db(dbname):
     exec_outside_of_transaction('CREATE DATABASE ' + dbname)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def db():
     """
     Attempt to connect to the database, retrying if necessary, and also
     creating the database if it doesn't already exist.
+
+    This will also ensure the database is empty when the test starts.
     """
 
     retries_left = 5

--- a/tests/test_wowutil.py
+++ b/tests/test_wowutil.py
@@ -1,0 +1,15 @@
+from nycdb.dataset import Dataset
+
+from .conftest import DATABASE_URL
+from load_dataset import Config
+import wowutil
+
+
+def test_it_works(db, slack_outbox):
+    config = Config(database_url=DATABASE_URL, use_test_data=True)
+    for dataset_name in wowutil.WOW_NYCDB_DEPENDENCIES:
+        ds = Dataset(dataset_name, args=config.nycdb_args)
+        ds.db_import()
+    wowutil.main(['build'], db_url=DATABASE_URL)
+    assert slack_outbox[0] == 'Rebuilding Who Owns What tables...'
+    assert slack_outbox[1] == 'Finished rebuilding Who Owns What tables.'

--- a/tests/test_wowutil.py
+++ b/tests/test_wowutil.py
@@ -1,3 +1,4 @@
+import psycopg2
 from nycdb.dataset import Dataset
 
 from .conftest import DATABASE_URL
@@ -11,5 +12,11 @@ def test_it_works(db, slack_outbox):
         ds = Dataset(dataset_name, args=config.nycdb_args)
         ds.db_import()
     wowutil.main(['build'], db_url=DATABASE_URL)
+
+    with psycopg2.connect(DATABASE_URL) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM wow.wow_bldgs")
+            assert cur.fetchone()[0] > 0
+
     assert slack_outbox[0] == 'Rebuilding Who Owns What tables...'
     assert slack_outbox[1] == 'Finished rebuilding Who Owns What tables.'

--- a/tests/test_wowutil.py
+++ b/tests/test_wowutil.py
@@ -18,5 +18,9 @@ def test_it_works(db, slack_outbox):
             cur.execute("SELECT COUNT(*) FROM wow.wow_bldgs")
             assert cur.fetchone()[0] > 0
 
+            # Make sure functions are defined, at least.
+            cur.execute("SET search_path TO wow, public")
+            cur.execute("SELECT wow.get_assoc_addrs_from_bbl('blah')")
+
     assert slack_outbox[0] == 'Rebuilding Who Owns What tables...'
     assert slack_outbox[1] == 'Finished rebuilding Who Owns What tables.'

--- a/tests/test_wowutil.py
+++ b/tests/test_wowutil.py
@@ -8,7 +8,7 @@ import wowutil
 
 def test_it_works(db, slack_outbox):
     config = Config(database_url=DATABASE_URL, use_test_data=True)
-    for dataset_name in wowutil.WOW_NYCDB_DEPENDENCIES:
+    for dataset_name in wowutil.WOW_YML['dependencies']:
         ds = Dataset(dataset_name, args=config.nycdb_args)
         ds.db_import()
     wowutil.main(['build'], db_url=DATABASE_URL)

--- a/wowutil.py
+++ b/wowutil.py
@@ -48,7 +48,7 @@ WOW_SCRIPTS: List[str] = WOW_YML['sql']
 def run_wow_sql(conn):
     with conn.cursor() as cur:
         for filename in WOW_SCRIPTS:
-            print(f"Runnig {filename}...")
+            print(f"Running {filename}...")
             sql = (WOW_SQL_DIR / filename).read_text()
             cur.execute(sql)
     conn.commit()
@@ -80,6 +80,7 @@ def build(db_url: str):
         # Note this means that any client which uses the functions will need
         # to set their search_path to "{WOW_SCHEMA}, public" or else the function
         # may not be found or might even crash!
+        print(f"Re-running CREATE FUNCTION statements in the {WOW_SCHEMA} schema...")
         sql = get_all_create_function_sql(WOW_SQL_DIR, WOW_SCRIPTS)
         run_sql_if_nonempty(conn, sql, initial_sql=f'SET search_path TO {WOW_SCHEMA}, public')
 

--- a/wowutil.py
+++ b/wowutil.py
@@ -1,0 +1,100 @@
+"""\
+Perform operations on the Who Owns What database tables.
+
+Usage:
+  wowutil.py build
+
+Options:
+  -h --help     Show this screen.
+
+Environment variables:
+  DATABASE_URL           The URL of the NYC-DB and WoW database.
+"""
+
+import sys
+import os
+from pathlib import Path
+from typing import List
+import docopt
+import psycopg2
+
+from lib import slack
+from load_dataset import (
+    create_temp_schema_name,
+    create_and_enter_temporary_schema,
+    save_and_reapply_permissions,
+    ensure_schema_exists,
+    drop_tables_if_they_exist,
+    change_table_schemas,
+    TableInfo
+)
+
+
+WOW_SCHEMA = 'wow'
+
+WOW_DIR = Path('/who-owns-what')
+
+# TODO: This eventually should be in the WoW repo and we should import it.
+WOW_NYCDB_DEPENDENCIES = [
+    # 'pluto_17v1',        # TODO: I don't think we actually need this one, but make sure.
+    'pluto_18v1',
+    'rentstab_summary',
+    'marshal_evictions_17',
+    'hpd_registrations',
+    'hpd_violations'
+]
+
+# TODO: This eventually should be in the WoW repo and we should import it.
+WOW_TABLES = ['wow_bldgs']
+
+# TODO: This eventually should be in the WoW repo and we should import it.
+WOW_SCRIPTS = [
+    ("Creating hpd_registrations_with_contacts...", 'registrations_with_contacts.sql'),
+    ("Creating WoW buildings table...", "create_bldgs_table.sql"),
+    ("Adding helper functions...", "helper_functions.sql"),
+    ("Creating WoW search function...", "search_function.sql"),
+    ("Creating WoW agg function...", "agg_function.sql"),
+    ("Creating hpd landlord contact table...", "landlord_contact.sql"),
+]
+
+
+def run_wow_sql(conn):
+    with conn.cursor() as cur:
+        for msg, filename in WOW_SCRIPTS:
+            print(msg)
+            sql = (WOW_DIR / 'sql' / filename).read_text()
+            cur.execute(sql)
+    conn.commit()
+
+
+def build(db_url: str):
+    slack.sendmsg('Rebuilding Who Owns What tables...')
+
+    cosmetic_dataset_name = 'wow'
+
+    tables = [
+        TableInfo(name=name, dataset=cosmetic_dataset_name)
+        for name in WOW_TABLES
+    ]
+
+    with psycopg2.connect(db_url) as conn:
+        temp_schema = create_temp_schema_name(cosmetic_dataset_name)
+        with create_and_enter_temporary_schema(conn, temp_schema):
+            run_wow_sql(conn)
+            ensure_schema_exists(conn, WOW_SCHEMA)
+            with save_and_reapply_permissions(conn, tables, WOW_SCHEMA):
+                drop_tables_if_they_exist(conn, tables, WOW_SCHEMA)
+                change_table_schemas(conn, tables, temp_schema, WOW_SCHEMA)
+
+    slack.sendmsg('Finished rebuilding Who Owns What tables.')
+
+
+def main(argv: List[str], db_url: str):
+    args = docopt.docopt(__doc__, argv=argv)
+
+    if args['build']:
+        build(db_url)
+
+
+if __name__ == '__main__':
+    main(argv=sys.argv[1:], db_url=os.environ['DATABASE_URL'])


### PR DESCRIPTION
Fixes #19 by putting Who Owns What data and functions in a `wow` schema.  Note that any clients who want to use functions defined in the schema will need to `SET search_path TO wow, public` or else the functions will either not be found, or crash.

Like NYCDB, the version of Who Owns What is specified via a git revision in the `Dockerfile`.

## Notes

* I opted to just add a new `wowutil.py` tool to deal with WoW data instead of the alternative, which was to decouple our concept of a "dataset" from NYCDB so we could then turn WoW into its own dataset. That would be a ton of work and I'm not sure if it's even the right decision architecturally, since WoW differs in a lot of ways from a standard NYCDB dataset (it has dependencies, it doesn't have any files that need to be downloaded from the internet, etc).

* Until now, the database wasn't actually being reset between tests, which made them run faster but wasn't good for test isolation.  Now the DB is wiped between tests, which unfortunately increases the test suite time from ~30s on CircleCI to ~45s. Oy. But I think it's for the best, and we don't really anticipate this codebase growing a lot in the future (and if it does, I'm sure we can figure out optimizations to make this take less time, e.g. wrapping tests in one big nested transaction or whatever it is that Django does).

* Until now, functions created in the SQL scripts for datasets weren't making their way into the `public` schema. They are now!

* Currently the test suite ensures that the version of NYCDB we're using is compatible with the version that WoW expects, and I *think* it's enough for now, but if it's not, we might want to revisit this later by e.g. making WoW itself a python package that's pinned to a particular version/range of NYCDB or something.

## To do

- [x] ~~There's constants in `wowutil.py` that really need to be moved over to the WoW repository and imported from there.~~  Merge https://github.com/JustFixNYC/who-owns-what/pull/102, which moves the metadata needed to properly install WoW over to the WoW repository.  Then point `WOW_REV` in the `Dockerfile` to the appropriate revision.
- [x] Make the test verify that `wow_bldgs` is created in the `wow` schema.
- [x] Make the test verify that functions are created in the `wow` schema.
- [x] Document `wowutil.py` in the README.
- [x] ~~Add some kind of command to allow the running of `wowutil.py build` to be scheduled on AWS Fargate.~~ Or perhaps just document ~~how~~ to do this manually for now.
