### PR TITLE
Allow 'wow' to be specified as a dataset for load_dataset.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ of the WoW data are already in the database at the time that
 The specific version of WoW used by `wowutil.py` is specified
 by the `WOW_REV` argument in the `Dockerfile`.
 
+As an alternative to running `wowutil.py`, you can also specify
+`wow` as the dataset for the `load_dataset.py` tool to load: this
+is essentially a shortcut for `wowutil.py build` and can be
+a convenient way to "slot in" the loading of WoW data to an
+already existing workflow for other NYCDB datasets.
+
 [Cron Jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 [NYC-DB]: https://github.com/aepyornis/nyc-db
 [Kubernetes Jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -247,6 +247,11 @@ def load_dataset(dataset: str, config: Config=Config(), force_check_urls: bool=F
     functionality with test data.
     '''
 
+    if dataset == 'wow':
+        import wowutil
+        wowutil.build(config.database_url)
+        return
+
     tables = get_tables_for_dataset(dataset)
     ds = Dataset(dataset, args=config.nycdb_args)
     ds.setup_db()


### PR DESCRIPTION
Ugh, it seems like the AWS console for running tasks doesn't allow the `CMD` override for a Docker container to actually contain multiple arguments to an executable, so I can't run `python wowutil.py build` through it manually, which is extremely annoying.  One workaround is to just allow `load_dataset.py` take `wow` as a dataset and have it shortcut to calling `wowutil.build()` if this is the case. It's not awesome but it gets the job done, and I've added docs to the README for it too.
