### PR TITLE
Ensure running 'wowutil.py build' twice works

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -152,7 +152,7 @@ def drop_tables_if_they_exist(conn, tables: List[TableInfo], schema: str):
         for table in tables:
             name = f"{schema}.{table.name}"
             print(f"Dropping table '{name}' if it exists.")
-            cur.execute(f"DROP TABLE IF EXISTS {name}")
+            cur.execute(f"DROP TABLE IF EXISTS {name} CASCADE")
     conn.commit()
 
 

--- a/tests/test_wowutil.py
+++ b/tests/test_wowutil.py
@@ -1,18 +1,16 @@
 import psycopg2
-from nycdb.dataset import Dataset
 
 from .conftest import DATABASE_URL
-from load_dataset import Config
+from load_dataset import Config, load_dataset
 import wowutil
 
 
-def test_it_works(db, slack_outbox):
-    config = Config(database_url=DATABASE_URL, use_test_data=True)
+def load_dependee_datasets(config: Config):
     for dataset_name in wowutil.WOW_YML['dependencies']:
-        ds = Dataset(dataset_name, args=config.nycdb_args)
-        ds.db_import()
-    wowutil.main(['build'], db_url=DATABASE_URL)
+        load_dataset(dataset_name, config)
 
+
+def ensure_wow_works():
     with psycopg2.connect(DATABASE_URL) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT COUNT(*) FROM wow.wow_bldgs")
@@ -22,8 +20,21 @@ def test_it_works(db, slack_outbox):
             cur.execute("SET search_path TO wow, public")
             cur.execute("SELECT wow.get_assoc_addrs_from_bbl('blah')")
 
-    assert slack_outbox[0] == 'Rebuilding Who Owns What tables...'
-    assert slack_outbox[1] == 'Finished rebuilding Who Owns What tables.'
+
+def test_it_works(db, slack_outbox):
+    config = Config(database_url=DATABASE_URL, use_test_data=True)
+    load_dependee_datasets(config)
+    wowutil.main(['build'], db_url=DATABASE_URL)
+
+    ensure_wow_works()
+    assert slack_outbox[-2] == 'Rebuilding Who Owns What tables...'
+    assert slack_outbox[-1] == 'Finished rebuilding Who Owns What tables.'
+
+    # Ensure that reloading the dependee datasets doesn't raise
+    # an exception.
+    load_dependee_datasets(config)
 
     # Ensure runing build again doesn't raise an exception.
     wowutil.main(['build'], db_url=DATABASE_URL)
+
+    ensure_wow_works()

--- a/tests/test_wowutil.py
+++ b/tests/test_wowutil.py
@@ -24,3 +24,6 @@ def test_it_works(db, slack_outbox):
 
     assert slack_outbox[0] == 'Rebuilding Who Owns What tables...'
     assert slack_outbox[1] == 'Finished rebuilding Who Owns What tables.'
+
+    # Ensure runing build again doesn't raise an exception.
+    wowutil.main(['build'], db_url=DATABASE_URL)

--- a/wowutil.py
+++ b/wowutil.py
@@ -60,14 +60,6 @@ def install_db_extensions(conn):
     conn.commit()
 
 
-def drop_functions_if_they_exist(conn, schema):
-    with conn.cursor() as cur:
-        # TODO: It would be nice if we didn't have to hard-code this, but
-        # apparently dropping all functions from a schema is non-trivial.
-        cur.execute(f'DROP FUNCTION IF EXISTS wow.get_assoc_addrs_from_bbl(text)')
-    conn.commit()
-
-
 def build(db_url: str):
     slack.sendmsg('Rebuilding Who Owns What tables...')
 
@@ -85,7 +77,6 @@ def build(db_url: str):
             run_wow_sql(conn)
             ensure_schema_exists(conn, WOW_SCHEMA)
             with save_and_reapply_permissions(conn, tables, WOW_SCHEMA):
-                drop_functions_if_they_exist(conn, WOW_SCHEMA)
                 drop_tables_if_they_exist(conn, tables, WOW_SCHEMA)
                 change_table_schemas(conn, tables, temp_schema, WOW_SCHEMA)
 


### PR DESCRIPTION
Um, so when I implemented #22, I forgot to make sure that running `wowutil.py build` _twice_ worked.

It looks like the WoW stuff requires the `pg_trgm` extension--I'm not really sure why it only complains about this the _second_ time we try building WoW datasets though.  So now we install the extension if it doesn't already exist. 

It also looks like we need to get rid of at least one function that depends on `wow_bldgs` before we destroy it, so this does that too. Oy vey!
