### PR TITLE
Update nycdb to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
 
 RUN pip install -r ${REQUIREMENTS_FILE}
 
-ARG NYCDB_REPO=https://github.com/toolness/nyc-db
-ARG NYCDB_REV=c151e2366b20050eb54d562105a3c63f5699bf1d
+ARG NYCDB_REPO=https://github.com/aepyornis/nyc-db
+ARG NYCDB_REV=47fb909718fb40efb155ee0e715aeef093019dfa
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
@@ -26,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nyc-db.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=1609c51f1ddada6accf13049691d88e2e7755a07
+ARG WOW_REV=5180baa002634ced6a01f65a5b574709f9fdaa86
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk update && \
   rm -rf /var/cache/apk/*
 
 ARG NYCDB_REPO=https://github.com/aepyornis/nyc-db
-ARG NYCDB_REV=572a7a1240720b70c07c6caec68048039ba5ee2b
+ARG NYCDB_REV=cea1ca97adc21bc8a84791b0ccc01ba551e0f6b2
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
-FROM python:3.6-alpine
+FROM python:3.6
 
 COPY requirements* /
 
 ARG REQUIREMENTS_FILE=requirements.txt
 
-RUN apk update && \
-  apk add postgresql-client unzip curl && \
-  apk add --virtual build-dependencies \
-    postgresql-dev \
-    gcc \
-    python3-dev \
-    musl-dev && \
-  pip install -r ${REQUIREMENTS_FILE} && \
-  apk del build-dependencies && \
-  rm -rf /var/cache/apk/*
+RUN apt-get update && \
+  apt-get install -y \
+    unzip \
+    postgresql-client && \
+  rm -rf /var/lib/apt/lists/*
 
-ARG NYCDB_REPO=https://github.com/aepyornis/nyc-db
-ARG NYCDB_REV=cea1ca97adc21bc8a84791b0ccc01ba551e0f6b2
+RUN pip install -r ${REQUIREMENTS_FILE}
+
+ARG NYCDB_REPO=https://github.com/toolness/nyc-db
+ARG NYCDB_REV=c151e2366b20050eb54d562105a3c63f5699bf1d
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
@@ -29,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nyc-db.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=cae0b6de35eba25df3376f6e890312aa55356c98
+ARG WOW_REV=1609c51f1ddada6accf13049691d88e2e7755a07
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/k8s_build_jobs.py
+++ b/k8s_build_jobs.py
@@ -33,7 +33,10 @@ def main(jobs_dir: Path=JOBS_DIR):
     ])
 
     for dataset in datasets:
-        template = yaml.load(JOB_TEMPLATE.read_text())
+        template = yaml.load(
+            JOB_TEMPLATE.read_text(),
+            Loader=yaml.FullLoader  # type: ignore
+        )
         name = template['metadata']['name']
         name = f"{name}-{slugify(dataset)}"
         template['metadata']['name'] = name

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,17 @@ chardet==3.0.4
 idna==2.8
 psycopg2==2.7.6.1
 pyproj==1.9.5.1
-PyYAML>=4.2b1
 requests==2.21.0
 tqdm==4.28.1
 urllib3==1.24.1
 xlrd==1.2.0
 sqlparse==0.2.4
 docopt
+
+# We'll pin pyproj to 1.x until nycdb is more compatible w/ 2.x:
+# https://github.com/aepyornis/nyc-db/pull/86
+pyproj==1.9.5.1
+# We'll also pin PyYAML until nyc-db upgrades to not emit warnings
+# from it:
+# https://github.com/aepyornis/nyc-db/pull/86
+PyYAML==4.2b4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,18 +2,11 @@ certifi==2018.11.29
 chardet==3.0.4
 idna==2.8
 psycopg2==2.7.6.1
-pyproj==1.9.5.1
+pyproj==2.1.3
 requests==2.21.0
 tqdm==4.28.1
-urllib3==1.24.1
+urllib3==1.24.2
 xlrd==1.2.0
 sqlparse==0.2.4
 docopt
-
-# We'll pin pyproj to 1.x until nycdb is more compatible w/ 2.x:
-# https://github.com/aepyornis/nyc-db/pull/86
-pyproj==1.9.5.1
-# We'll also pin PyYAML until nyc-db upgrades to not emit warnings
-# from it:
-# https://github.com/aepyornis/nyc-db/pull/86
-PyYAML==4.2b4
+PyYAML>=5.1

--- a/wowutil.py
+++ b/wowutil.py
@@ -40,7 +40,10 @@ WOW_DIR = Path('/who-owns-what')
 
 WOW_SQL_DIR = Path(WOW_DIR / 'sql')
 
-WOW_YML = yaml.load((WOW_DIR / 'who-owns-what.yml').read_text())
+WOW_YML = yaml.load(
+    (WOW_DIR / 'who-owns-what.yml').read_text(),
+    Loader=yaml.FullLoader  # type: ignore
+)
 
 WOW_SCRIPTS: List[str] = WOW_YML['sql']
 


### PR DESCRIPTION
This updates NYCDB to rev aepyornis/nyc-db@cea1ca97adc21bc8a84791b0ccc01ba551e0f6b2.  It also pins some dependencies until the issues mentioned in https://github.com/aepyornis/nyc-db/pull/86 are resolved.

## To do

- [ ] Once this is merged, I think that I'll have to see if any new datasaets have been added since the last time we updated, and if so I'll need to re-run the script that creates scheduled tasks for each dataset.
