### PR TITLE
upgrade to nycdb version 0.1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip install -r ${REQUIREMENTS_FILE}
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=3924be93af4c7ffac0a38c76c97831f25edd032c
+ARG NYCDB_REV=d43332f129522d13ad0c47e608c130aeb6faf4ff
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip install -r ${REQUIREMENTS_FILE}
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=7547ed6979af5890a4f72a916f9a2da090fd752e
+ARG NYCDB_REV=3924be93af4c7ffac0a38c76c97831f25edd032c
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/aws_schedule_tasks.py
+++ b/aws_schedule_tasks.py
@@ -70,6 +70,7 @@ DATASET_SCHEDULES: Dict[str, str] = {
     'ecb_violations': DAILY,
     'hpd_violations': DAILY,
     'oath_hearings': DAILY,
+    'hpd_vacateorders': EVERY_OTHER_DAY,
     'hpd_registrations': EVERY_OTHER_DAY,
     'hpd_complaints': EVERY_OTHER_DAY,
     'dof_sales': EVERY_OTHER_DAY,


### PR DESCRIPTION
Fixes #37 by upgrading to nycdb version 0.1.25, updating the Dockerfile with the nycdb commit tag and adding the new `hpd_vacateorders` dataset to the aws tasks