### PR TITLE
Update wow ref to include new 2019 marshal evictions data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=423ccc47a1922a3c5076822227d12640ed26e74c
+ARG WOW_REV=a2f4d2b1416ba7d9780b90b31202f3833efbae8d
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR updates the reference to the Who Owns What codebase in our kubernetes loader. The new Who Owns What code includes a build script involving the updated 2019 evictions data.