### PR TITLE
Update reference to WOW codebase to make use of new SQL code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=a2f4d2b1416ba7d9780b90b31202f3833efbae8d
+ARG WOW_REV=b8b66a03ea025cbb2f8b025aa86dbe94026c2a1a
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=b8b66a03ea025cbb2f8b025aa86dbe94026c2a1a
+ARG WOW_REV=10286cb43645040e67a4c4044d185712671c4589
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR updates our reference to the newest version of WOW so that we can use a new version of our SQL code that generates the `wow_bldgs` table (which now includes most recent sale data).