### PR TITLE
Support CREATE TABLE statements w/ IdentifierLists in them.

### DIFF
--- a/lib/parse_created_tables.py
+++ b/lib/parse_created_tables.py
@@ -2,21 +2,30 @@ from typing import List
 from pathlib import Path
 from functools import lru_cache
 import sqlparse
-from sqlparse.sql import Identifier
+from sqlparse.sql import Identifier, IdentifierList
 import nycdb
 
 
 NYCDB_SQL_DIR = Path(nycdb.__file__).parent.resolve() / 'sql'
 
 
+def get_identifiers(stmt) -> List[Identifier]:
+    identifiers: List[Identifier] = []
+    for token in stmt.tokens:
+        if isinstance(token, IdentifierList):
+            token = token.tokens[0]
+        if isinstance(token, Identifier):
+            identifiers.append(str(token.tokens[0]))
+    return identifiers
+
+
 def parse_created_tables(sql: str) -> List[str]:
     tables: List[str] = []
 
     for stmt in sqlparse.parse(sql):
-        identifiers = [
-            str(token.tokens[0]) for token in stmt.tokens
-            if isinstance(token, Identifier)
-        ]
+        for token in stmt.tokens:
+            print(repr(token), token.__class__.__name__)
+        identifiers = get_identifiers(stmt)
         keywords = [
             str(token).upper() for token in stmt.tokens
             if token.is_keyword

--- a/tests/sql/wow_new_create_bldgs_table.sql
+++ b/tests/sql/wow_new_create_bldgs_table.sql
@@ -1,0 +1,82 @@
+drop table if exists wow_bldgs cascade;
+
+-- This is mainly used as an easy way to provide contact info on request, not a replacement
+-- for cross-table analysis. Hence why the corpnames, businessaddrs, and ownernames are simplified
+-- with JSON and such.
+create table wow_bldgs as 
+
+with deeds as (
+	select 
+    	m.documentid,
+    	coalesce(m.docdate,m.recordedfiled) docdate,
+    	m.docamount, 
+    	l.bbl
+	from real_property_master m
+	left join real_property_legals l using(documentid)
+	where docamount > 1 and doctype = any('{DEED,DEEDO}')
+	order by docdate desc
+),
+
+firstdeeds as (
+  select 
+    d.bbl,
+    first(d.documentid) documentid,
+    first(d.docdate) docdate,
+    first(d.docamount) docamount
+  from deeds d
+  group by bbl
+)
+
+select distinct on (registrations.bbl)
+  registrations.*,
+  coalesce(violations.total, 0)::int as totalviolations,
+  coalesce(violations.opentotal, 0)::int as openviolations,
+  pluto.unitsres,
+  pluto.yearbuilt,
+  pluto.lat,
+  pluto.lng,
+  evictions.evictions,
+  rentstab.unitsstab2007 as rsunits2007,
+  rentstab.unitsstab2017 as rsunits2017,
+  rentstab.diff as rsdiff,
+  rentstab.percentchange as rspercentchange,
+  firstdeeds.documentid as lastsaleacrisid,
+  firstdeeds.docdate as lastsaledate,
+  firstdeeds.docamount as lastsaleamount
+from hpd_registrations_with_contacts as registrations
+left join (
+  select bbl,
+    count(case when violationstatus = 'Open' then 1 end) as opentotal,
+    count(*) as total
+  from hpd_violations
+  group by bbl
+) violations on (registrations.bbl = violations.bbl)
+left join (
+  select
+    bbl,
+    unitsres,
+    yearbuilt,
+    lat, lng
+  from pluto_19v2
+) pluto on (registrations.bbl = pluto.bbl)
+left join (
+  select
+    bbl,
+    count(*) as evictions
+  from marshal_evictions_19
+  where residentialcommercialind = 'RESIDENTIAL'
+  group by bbl
+) evictions on (registrations.bbl = evictions.bbl)
+left join (
+  select
+    ucbbl,
+    unitsstab2007,
+    unitsstab2017,
+    diff,
+    percentchange
+  from rentstab_summary
+) rentstab on (registrations.bbl = rentstab.ucbbl)
+left join firstdeeds on (registrations.bbl = firstdeeds.bbl);
+
+create index on wow_bldgs (registrationid);
+create index on wow_bldgs (bbl);

--- a/tests/sql/wow_old_create_bldgs_table.sql
+++ b/tests/sql/wow_old_create_bldgs_table.sql
@@ -1,0 +1,55 @@
+DROP TABLE IF EXISTS wow_bldgs CASCADE;
+
+-- This is mainly used as an easy way to provide contact info on request, not a replacement
+-- for cross-table analysis. Hence why the corpnames, businessaddrs, and ownernames are simplified
+-- with JSON and such.
+CREATE TABLE wow_bldgs
+AS SELECT DISTINCT ON (registrations.bbl)
+registrations.*,
+coalesce(violations.total, 0)::int as totalviolations,
+coalesce(violations.opentotal, 0)::int as openviolations,
+pluto.unitsres,
+pluto.yearbuilt,
+pluto.lat,
+pluto.lng,
+evictions.evictions,
+rentstab.unitsstab2007 as rsunits2007,
+rentstab.unitsstab2017 as rsunits2017,
+rentstab.diff as rsdiff,
+rentstab.percentchange as rspercentchange
+FROM hpd_registrations_with_contacts AS registrations
+LEFT JOIN (
+SELECT bbl,
+    count(CASE WHEN violationstatus = 'Open' THEN 1 END) as opentotal,
+    count(*) as total
+FROM hpd_violations
+GROUP BY bbl
+) violations ON (registrations.bbl = violations.bbl)
+LEFT JOIN (
+SELECT
+    bbl,
+    unitsres,
+    yearbuilt,
+    lat, lng
+FROM pluto_19v2
+) pluto ON (registrations.bbl = pluto.bbl)
+LEFT JOIN (
+SELECT
+    bbl,
+    count(*) as evictions
+FROM marshal_evictions_19
+WHERE residentialcommercialind = 'RESIDENTIAL'
+GROUP BY bbl
+) evictions ON (registrations.bbl = evictions.bbl)
+LEFT JOIN (
+SELECT
+    ucbbl,
+    unitsstab2007,
+    unitsstab2017,
+    diff,
+    percentchange
+FROM rentstab_summary
+) rentstab ON (registrations.bbl = rentstab.ucbbl);
+
+create index on wow_bldgs (registrationid);
+create index on wow_bldgs (bbl);

--- a/tests/test_parse_created_tables.py
+++ b/tests/test_parse_created_tables.py
@@ -1,7 +1,14 @@
+from pathlib import Path
+
+
 from lib.parse_created_tables import (
     parse_created_tables,
     parse_nycdb_created_tables
 )
+
+MY_DIR = Path(__file__).parent.resolve()
+
+SQL_DIR = MY_DIR / 'sql'
 
 
 def test_it_returns_empty_list_when_no_tables_are_created():
@@ -38,6 +45,19 @@ def test_it_parses_create_table_statements_2():
     """
 
     assert parse_created_tables(sql) == ['foo']
+
+
+
+def test_it_parses_old_create_table_statements_in_wow():
+    sql = (SQL_DIR / "wow_old_create_bldgs_table.sql").read_text()
+
+    assert parse_created_tables(sql) == ['wow_bldgs']
+
+
+def test_it_parses_new_create_table_statements_in_wow():
+    sql = (SQL_DIR / "wow_new_create_bldgs_table.sql").read_text()
+
+    assert parse_created_tables(sql) == ['wow_bldgs']
 
 
 def test_it_parses_nycdb_files():


### PR DESCRIPTION
It looks like #47 is failing because the code we use to parse SQL files to detect what tables are being created by them isn't accounting for `IdentifierList` tokens from the `sqlparse` library, which apparently the SQL for WoW's new `create_bldgs_table` uses.  This adds support for them and makes sure that both WoW's new and old `create_bldgs_table` parse as expected.
