### PR TITLE
Add oca

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=a2f4d2b1416ba7d9780b90b31202f3833efbae8d
+ARG WOW_REV=ff23fc0065d7deca3a0f89cdf2bf234b0bb68f62
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip install -r ${REQUIREMENTS_FILE}
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=630f2d8b4322b96bcf0b145cbe306a010c03960d
+ARG NYCDB_REV= ada7c041a5bf6ba32832e6cf62a0fd66e1a3ccce
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN pip install -r ${REQUIREMENTS_FILE}
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV= ada7c041a5bf6ba32832e6cf62a0fd66e1a3ccce
+ARG NYCDB_REV=ada7c041a5bf6ba32832e6cf62a0fd66e1a3ccce
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
@@ -26,7 +26,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=ff23fc0065d7deca3a0f89cdf2bf234b0bb68f62
+ARG WOW_REV=a2f4d2b1416ba7d9780b90b31202f3833efbae8d
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/aws_schedule_tasks.py
+++ b/aws_schedule_tasks.py
@@ -64,6 +64,7 @@ YEARLY = 'rate(365 days)'
 DEFAULT_SCHEDULE_EXPRESSION = YEARLY
 
 DATASET_SCHEDULES: Dict[str, str] = {
+    'oca': DAILY,
     'dobjobs': DAILY,
     'dob_complaints': DAILY,
     'dob_violations': DAILY,


### PR DESCRIPTION
I've finalized the addition of the oca to nycdb, and this is the final git commit hash. 

The OCA data is made available on the SFTP every Monday overnight, and I've been running to process to update the public CSV files every Tuesday. However, I haven't yet set up an automated task for this so until I do it's possible that I could be a day late, and so I thought it would be safer to set this as a daily dataset instead of adding a new cron time string for weekly on Tuesday. 