### PR TITLE
On push to master, build and push production container to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
+      image: ubuntu-1604:202004-01
     working_directory: ~/repo
     steps:
       - checkout
@@ -11,6 +12,7 @@ jobs:
           # here to ensure that layers are cached properly. This works around
           # https://github.com/docker/compose/issues/883.
           command: |
+            docker-compose --version
             docker build --target dev -t justfixnyc/nycdb-k8s-loader:dev .
             cp .env.example .env
             docker-compose run app pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,6 @@ jobs:
             cp .env.example .env
             docker-compose run app pytest
       - run:
-        name: build production container
-        command: |
-          docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .
+          name: build production container
+          command: |
+            docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,23 @@ jobs:
     steps:
       - checkout
       - run:
-          name: run tests
+          name: build base container
           # Note that we want to run `docker build` rather than `docker-compose build`
           # here to ensure that layers are cached properly. This works around
           # https://github.com/docker/compose/issues/883.
           command: |
-            docker-compose --version
+            docker --version
+            docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
             docker build --target dev -t justfixnyc/nycdb-k8s-loader:dev .
-            cp .env.example .env
-            docker-compose run app pytest
+      # TODO: THE FOLLOWING COMMENTS ARE TEMPORARY
+      # - run:
+      #     name: run tests
+      #     command: |
+      #       docker-compose --version
+      #       cp .env.example .env
+      #       docker-compose run app pytest
       - run:
           name: build production container
           command: |
             docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .
+            docker push justfixnyc/nycdb-k8s-loader:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,14 @@ jobs:
       - checkout
       - run:
           name: run tests
+          # Note that we want to run `docker build` rather than `docker-compose build`
+          # here to ensure that layers are cached properly. This works around
+          # https://github.com/docker/compose/issues/883.
           command: |
+            docker build --target dev -t justfixnyc/nycdb-k8s-loader:dev .
             cp .env.example .env
             docker-compose run app pytest
+      - run:
+        name: build production container
+        command: |
+          docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,16 +14,18 @@ jobs:
           command: |
             docker --version
             docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
-            docker build --target dev -t justfixnyc/nycdb-k8s-loader:dev .
-      # TODO: THE FOLLOWING COMMENTS ARE TEMPORARY
-      # - run:
-      #     name: run tests
-      #     command: |
-      #       docker-compose --version
-      #       cp .env.example .env
-      #       docker-compose run app pytest
+            docker pull justfixnyc/nycdb-k8s-loader:latest
+            docker build --cache-from justfixnyc/nycdb-k8s-loader:latest --target dev -t justfixnyc/nycdb-k8s-loader:dev .
+      - run:
+          name: run tests
+          command: |
+            docker-compose --version
+            cp .env.example .env
+            docker-compose run app pytest
       - run:
           name: build production container
           command: |
-            docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .
-            docker push justfixnyc/nycdb-k8s-loader:latest
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+              docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .
+              docker push justfixnyc/nycdb-k8s-loader:latest
+            fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '2'
+version: '3.4'
 services:
   app:
-    image: nycdb-load-dataset:boop
+    image: justfixnyc/nycdb-k8s-loader:dev
     build:
       context: .
-      args:
-        REQUIREMENTS_FILE: requirements.dev.txt
+      target: dev
     volumes:
       - .:/app
     environment:

--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
       - name: load-dataset
-        image: nycdb-load-dataset:boop
+        image: justfixnyc/nycdb-k8s-loader:dev
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
This is an attempt to use Docker multi-stage builds to both test the code _and_ push the production container to Docker Hub.  This ensures that once CircleCI says a build is done, we know that our production infrastructure is updated, rather than having to wait for Docker Hub's auto-builder to complete (and possibly hiccup and fail, which has happened in the past).

In a future PR, we will also run the `aws_schedule_tasks.py` script after pushing to production to ensure that production infrastructure is updated whenever this repo's `master` branch is.

## To do

- [x] Use multi-stage builds to test the code and build the production container separately.
- [x] Push the production container to Docker Hub.
- [x] Make sure we only push to Docker Hub and run `aws_schedule_tasks.py` if we're on `master`. We can use a conditional based on `${CIRCLE_BRANCH}`, see our [tenants2 CircleCI config](https://github.com/JustFixNYC/tenants2/blob/master/.circleci/config.yml) for an example.
