### PR TITLE
Run aws_schedule_tassk.py in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,20 +18,24 @@ jobs:
             docker --version
             docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
             docker pull justfixnyc/nycdb-k8s-loader:latest
-            docker build --cache-from justfixnyc/nycdb-k8s-loader:latest --target dev -t justfixnyc/nycdb-k8s-loader:dev .
-            # TODO: move this to post-production container build/push
-            docker-compose run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} app python aws_schedule_tasks.py create ${CLUSTER_NAME}
-      # TODO: UNCOMMENT NEXT LINES
-      # - run:
-      #     name: run tests
-      #     command: |
-      #       docker-compose --version
-      #       cp .env.example .env
-      #       docker-compose run app pytest
+            docker build --cache-from justfixnyc/nycdb-k8s-loader:latest --target dev \
+              -t justfixnyc/nycdb-k8s-loader:dev .
+      TODO: UNCOMMENT NEXT LINES
       - run:
-          name: build production container
+          name: run tests
+          command: |
+            docker-compose --version
+            cp .env.example .env
+            docker-compose run app pytest
+      - run:
+          name: build and push production container (master branch only)
           command: |
             if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
               docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .
               docker push justfixnyc/nycdb-k8s-loader:latest
+              docker-compose run \
+                -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+                -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+                -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} \
+                app python aws_schedule_tasks.py create ${CLUSTER_NAME}
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     machine:
       image: ubuntu-1604:202004-01
+    environment:
+      CLUSTER_NAME: atul-default
+      AWS_DEFAULT_REGION: us-east-1
     working_directory: ~/repo
     steps:
       - checkout
@@ -16,12 +19,15 @@ jobs:
             docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
             docker pull justfixnyc/nycdb-k8s-loader:latest
             docker build --cache-from justfixnyc/nycdb-k8s-loader:latest --target dev -t justfixnyc/nycdb-k8s-loader:dev .
-      - run:
-          name: run tests
-          command: |
-            docker-compose --version
-            cp .env.example .env
-            docker-compose run app pytest
+            # TODO: move this to post-production container build/push
+            docker run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} justfixnyc/nycdb-k8s-loader:dev python aws_schedule_tasks.py create ${CLUSTER_NAME}
+      # TODO: UNCOMMENT NEXT LINES
+      # - run:
+      #     name: run tests
+      #     command: |
+      #       docker-compose --version
+      #       cp .env.example .env
+      #       docker-compose run app pytest
       - run:
           name: build production container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             docker pull justfixnyc/nycdb-k8s-loader:latest
             docker build --cache-from justfixnyc/nycdb-k8s-loader:latest --target dev -t justfixnyc/nycdb-k8s-loader:dev .
             # TODO: move this to post-production container build/push
-            docker run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} justfixnyc/nycdb-k8s-loader:dev python aws_schedule_tasks.py create ${CLUSTER_NAME}
+            docker-compose run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} app python aws_schedule_tasks.py create ${CLUSTER_NAME}
       # TODO: UNCOMMENT NEXT LINES
       # - run:
       #     name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
             docker pull justfixnyc/nycdb-k8s-loader:latest
             docker build --cache-from justfixnyc/nycdb-k8s-loader:latest --target dev \
               -t justfixnyc/nycdb-k8s-loader:dev .
-      TODO: UNCOMMENT NEXT LINES
       - run:
           name: run tests
           command: |


### PR DESCRIPTION
This builds on #51 to run the `aws_schedule_tasks.py` script after pushing to production to ensure that production infrastructure is updated whenever this repo's `master` branch is.