### PR TITLE
Update NYCDB to new version with 2019 rentstab unit counts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=ada7c041a5bf6ba32832e6cf62a0fd66e1a3ccce
+ARG NYCDB_REV=be13215c3b2368a52a62dbfd027d7cc8d76f75cb
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/k8s_build_jobs.py
+++ b/k8s_build_jobs.py
@@ -35,7 +35,7 @@ def main(jobs_dir: Path=JOBS_DIR):
     for dataset in datasets:
         template = yaml.load(
             JOB_TEMPLATE.read_text(),
-            Loader=yaml.FullLoader  # type: ignore
+            Loader=yaml.FullLoader
         )
         name = template['metadata']['name']
         name = f"{name}-{slugify(dataset)}"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-mypy==0.650
+mypy==0.782
 pytest
 requests-mock
 boto3

--- a/wowutil.py
+++ b/wowutil.py
@@ -42,7 +42,7 @@ WOW_SQL_DIR = Path(WOW_DIR / 'sql')
 
 WOW_YML = yaml.load(
     (WOW_DIR / 'who-owns-what.yml').read_text(),
-    Loader=yaml.FullLoader  # type: ignore
+    Loader=yaml.FullLoader
 )
 
 WOW_SCRIPTS: List[str] = WOW_YML['sql']


### PR DESCRIPTION
This PR updates our reference to the nycdb codebase, which includes an updated version of the `rentstab_v2` table with new unit count values for 2019. This also upgrades our `mypy` package to fix a bug around unused "type: ignore" comments in our python code.