### PR TITLE
Update WOW_REV to remove old 'rentstab2017' field from wow_bldgs table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=96782e3967f5fd5e556152109922a628d624e065
+ARG WOW_REV=f9c7a67ff298904d67fd113636766d4ac0196598
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR is a simple update of our reference to the Who Owns What codebase, in order to remove an unneeded 'rentstab2017' field from the custom wow_bldgs table.