### PR TITLE
Use pip 20.2.4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ RUN apt-get update && \
     postgresql-client && \
   rm -rf /var/lib/apt/lists/*
 
+# The latest version of pip at the time of this writing, 20.3, results
+# in an infinite loop of "Requirement already satisfied" when
+# installing our dependencies, so we're forcibly downgrading to
+# the most recent version that works.
+RUN python -m pip install pip==20.2.4
+
 COPY requirements.txt /
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Due to https://github.com/pypa/pip/issues/9187, building the container with pip 20.3 results in either an infinite loop or an _extremely_ long build time, so this rolls us back to pip 20.2.4, which works fine.