### PR TITLE
Update nycdb to most recent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=f8fd5898e407eeb84469517d847e0b9079936147
+ARG NYCDB_REV=957e019e94710f9de581e807218591f35c697a63
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -55,7 +55,8 @@ class Config(NamedTuple):
             host=DB_HOST,
             database=DB_NAME,
             port=str(DB_PORT),
-            root_dir=str(TEST_DATA_DIR) if self.use_test_data else str(NYCDB_DATA_DIR)
+            root_dir=str(TEST_DATA_DIR) if self.use_test_data else str(NYCDB_DATA_DIR),
+            hide_progress=False,
         )
 
 


### PR DESCRIPTION
This PR updates the version of nycdb that our auto-updating loader makes use of. Notable new changes include the addition of the `pluto_20v8` table as well as the reintroduction of hyphens to HPD business addresses.