### PR TITLE
Update WOW version to include new wow_bldgs SQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=f9c7a67ff298904d67fd113636766d4ac0196598
+ARG WOW_REV=b301172f7bad4abc908be5aaa3dc2ef0a7181c1e
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR updates which version of the Who Owns What codebase we reference, making use of the new evictions data in the `wow_bldgs` table implemented in https://github.com/JustFixNYC/who-owns-what/pull/435.