### PR TITLE
Update nycdb version to include NYCHA data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=6055e54c54613a893a4ef6f41e82cf9276b2233e
+ARG NYCDB_REV=beafdf6b88a27855f157e466029dd40693701377
 
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of


### PR DESCRIPTION
This PR updates the version of nycdb that our auto-updating loader makes use of. Notable new changes include the addition of the `nycha_bbls` dataset.