### PR TITLE
Update WOW_REV to point to new WOW SQL code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=2ff521446e6acac7e70cd8bc7f8fec754f87e577
+ARG WOW_REV=cc22c2aee8581e6fb9e3a78a1f29b0cabf6898eb
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR updated the SHA code that references the version of Who Owns What code that we use to build our db—specifically including changes to the hpd_registrations_with_contacts table included in JustFixNYC/who-owns-what#477.