### PR TITLE
Make k8s cron jobs work again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .git/
-jobs/
+k8s-jobs/
 Dockerfile
 docker-compose.yml
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Then tell k8s to start your jobs:
 kubectl create -f ./k8s-jobs
 ```
 
-Now you can visit the "Jobs" section of your Kubernetes Dashboard to see
+Now you can visit the "Cron Jobs" section of your Kubernetes Dashboard to see
 the state of the jobs.
 
 If you want to stop the jobs, or clean them up once they're finished, run:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ introspecting the state of the NYC-DB dataset loader jobs very easy.
 You'll want to build your container image by running:
 
 ```
-docker-compose build
+docker build --target prod -t justfixnyc/nycdb-k8s-loader:latest .
 ```
 
 To deploy the jobs to your Kubernetes cluster, first generate job files:

--- a/aws_schedule_tasks.py
+++ b/aws_schedule_tasks.py
@@ -43,40 +43,31 @@ import boto3
 import docopt
 import dotenv
 import nycdb.dataset
+from scheduling import Schedule
 
 dotenv.load_dotenv()
 
 # The names of all valid NYC-DB datasets.
 DATASET_NAMES: List[str] = list(nycdb.dataset.datasets().keys())
 
-# Various schedule expressions. Note that all times must be specified
-# in UTC.
-#
-# For more details on schedule expressions, see:
-#
-# https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
-DAILY = 'cron(0 5 * * ? *)'               # Daily at around midnight EST.
-EVERY_OTHER_DAY = 'cron(0 5 */2 * ? *)'   # Every other day around midnight EST.
-YEARLY = 'rate(365 days)'
-
-# The default schedule expression for a dataset loader, if
+# The default schedule for a dataset loader, if
 # otherwise unspecified.
-DEFAULT_SCHEDULE_EXPRESSION = YEARLY
+DEFAULT_SCHEDULE = Schedule.YEARLY
 
-DATASET_SCHEDULES: Dict[str, str] = {
-    'oca': DAILY,
-    'dobjobs': DAILY,
-    'dob_complaints': DAILY,
-    'dob_violations': DAILY,
-    'ecb_violations': DAILY,
-    'hpd_violations': DAILY,
-    'oath_hearings': DAILY,
-    'hpd_vacateorders': EVERY_OTHER_DAY,
-    'hpd_registrations': EVERY_OTHER_DAY,
-    'hpd_complaints': EVERY_OTHER_DAY,
-    'dof_sales': EVERY_OTHER_DAY,
-    'pad': EVERY_OTHER_DAY,
-    'acris': EVERY_OTHER_DAY
+DATASET_SCHEDULES: Dict[str, Schedule] = {
+    'oca': Schedule.DAILY,
+    'dobjobs': Schedule.DAILY,
+    'dob_complaints': Schedule.DAILY,
+    'dob_violations': Schedule.DAILY,
+    'ecb_violations': Schedule.DAILY,
+    'hpd_violations': Schedule.DAILY,
+    'oath_hearings': Schedule.DAILY,
+    'hpd_vacateorders': Schedule.EVERY_OTHER_DAY,
+    'hpd_registrations': Schedule.EVERY_OTHER_DAY,
+    'hpd_complaints': Schedule.EVERY_OTHER_DAY,
+    'dof_sales': Schedule.EVERY_OTHER_DAY,
+    'pad': Schedule.EVERY_OTHER_DAY,
+    'acris': Schedule.EVERY_OTHER_DAY
 }
 
 
@@ -133,7 +124,7 @@ def create_task(
     '''
 
     name = f"{prefix}{dataset}"
-    schedule_expression = DATASET_SCHEDULES.get(dataset, DEFAULT_SCHEDULE_EXPRESSION)
+    schedule_expression = DATASET_SCHEDULES.get(dataset, DEFAULT_SCHEDULE).aws
 
     print(f"Creating rule '{name}' with schedule {schedule_expression}.")
     client = boto3.client('events')

--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -1,12 +1,14 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: load-dataset
 spec:
-  template:
+  jobTemplate:
     spec:
-      containers:
-      - name: load-dataset
-        image: justfixnyc/nycdb-k8s-loader:dev
-      restartPolicy: Never
-  backoffLimit: 4
+      template:
+        spec:
+          containers:
+          - name: load-dataset
+            image: justfixnyc/nycdb-k8s-loader:dev
+          restartPolicy: Never
+      backoffLimit: 4

--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -9,6 +9,5 @@ spec:
         spec:
           containers:
           - name: load-dataset
-            image: justfixnyc/nycdb-k8s-loader:dev
           restartPolicy: Never
       backoffLimit: 4

--- a/k8s_build_jobs.py
+++ b/k8s_build_jobs.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
+import argparse
 import yaml
 
 from scheduling import DATASET_NAMES, get_schedule_for_dataset
@@ -11,7 +12,16 @@ MY_DIR = Path(__file__).parent.resolve()
 
 JOB_TEMPLATE = MY_DIR / 'k8s-job-template.yml'
 
-JOBS_DIR = MY_DIR / 'k8s-jobs'
+DEFAULT_JOBS_DIR = MY_DIR / 'k8s-jobs'
+
+DEFAULT_IMAGE = 'justfixnyc/nycdb-k8s-loader:latest'
+
+CONTAINER_ENV_VARS = [
+    'DATABASE_URL',
+    'USE_TEST_DATA',
+    'SLACK_WEBHOOK_URL',
+    'ROLLBAR_ACCESS_TOKEN'
+]
 
 
 def get_env(name: str) -> Dict[str, str]:
@@ -25,8 +35,24 @@ def slugify(name: str) -> str:
     return name.replace('_', '-')
 
 
-def main(jobs_dir: Path=JOBS_DIR):
+def main(args: List[str]):
     load_dataset.sanity_check()
+
+    parser = argparse.ArgumentParser(
+        description="Build Kubernetes CronJobs to load NYCDB datasets."
+    )
+    parser.add_argument(
+        '--jobs-dir', default=DEFAULT_JOBS_DIR,
+        help=f'Directory to write files (default is "{DEFAULT_JOBS_DIR}")'
+    )
+    parser.add_argument(
+        '--image', default=DEFAULT_IMAGE,
+        help=f'Container image to use (default is "{DEFAULT_IMAGE}")'
+    )
+
+    pargs = parser.parse_args(args)
+
+    jobs_dir = Path(pargs.jobs_dir)
     jobs_dir.mkdir(parents=True, exist_ok=True)
 
     for dataset in DATASET_NAMES:
@@ -39,15 +65,13 @@ def main(jobs_dir: Path=JOBS_DIR):
         template['metadata']['name'] = name
         template['spec']['schedule'] = get_schedule_for_dataset(dataset).k8s
         c = template['spec']['jobTemplate']['spec']['template']['spec']['containers'][0]
+        c['image'] = pargs.image
         c['command'] = [
             'python',
             Path(load_dataset.__file__).name,
             dataset
         ]
-        c['env'] = [
-            get_env('DATABASE_URL'),
-            get_env('USE_TEST_DATA')
-        ]
+        c['env'] = [get_env(varname) for varname in CONTAINER_ENV_VARS]
         outfile = jobs_dir / f'load_dataset_{dataset}.yml'
         print(f"Writing {outfile}.")
         outfile.write_text(yaml.dump(template))
@@ -55,4 +79,6 @@ def main(jobs_dir: Path=JOBS_DIR):
 
 
 if __name__ == '__main__':
-    main()
+    import sys
+
+    main(sys.argv[1:])

--- a/scheduling.py
+++ b/scheduling.py
@@ -1,4 +1,6 @@
 from enum import Enum
+from typing import Dict, List
+import nycdb.dataset
 
 
 class Schedule(Enum):
@@ -43,3 +45,39 @@ class Schedule(Enum):
         """
 
         return self.value
+
+
+# The names of all valid NYC-DB datasets.
+DATASET_NAMES: List[str] = list(nycdb.dataset.datasets().keys())
+
+# The default schedule for a dataset loader, if
+# otherwise unspecified.
+DEFAULT_SCHEDULE = Schedule.YEARLY
+
+DATASET_SCHEDULES: Dict[str, Schedule] = {
+    'oca': Schedule.DAILY,
+    'dobjobs': Schedule.DAILY,
+    'dob_complaints': Schedule.DAILY,
+    'dob_violations': Schedule.DAILY,
+    'ecb_violations': Schedule.DAILY,
+    'hpd_violations': Schedule.DAILY,
+    'oath_hearings': Schedule.DAILY,
+    'hpd_vacateorders': Schedule.EVERY_OTHER_DAY,
+    'hpd_registrations': Schedule.EVERY_OTHER_DAY,
+    'hpd_complaints': Schedule.EVERY_OTHER_DAY,
+    'dof_sales': Schedule.EVERY_OTHER_DAY,
+    'pad': Schedule.EVERY_OTHER_DAY,
+    'acris': Schedule.EVERY_OTHER_DAY
+}
+
+
+def get_schedule_for_dataset(dataset: str) -> Schedule:
+    return DATASET_SCHEDULES.get(dataset, DEFAULT_SCHEDULE)
+
+
+def sanity_check():
+    for dataset in DATASET_SCHEDULES:
+        assert dataset in DATASET_NAMES, f"'{dataset}' must be a valid NYCDB dataset name"
+
+
+sanity_check()

--- a/scheduling.py
+++ b/scheduling.py
@@ -1,0 +1,45 @@
+from enum import Enum
+
+
+class Schedule(Enum):
+    """
+    Abstracts away scheduling frequency from the particular
+    scheduling technology being used (AWS, k8s, etc).
+    """
+
+    # Daily at around midnight EST.
+    DAILY = "0 5 * * ? *"
+
+    # Every other day around midnight EST.
+    EVERY_OTHER_DAY = '0 5 */2 * ? *'
+
+    # Once per year.
+    YEARLY = "@yearly"
+
+    @property
+    def aws(self) -> str:
+        """
+        The schedule in terms Amazon Web Services (AWS) expects.
+
+        Note that all times must be specified in UTC.
+
+        For more details on AWS's schedule expressions, see:
+
+        https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+        """
+
+        if self == Schedule.YEARLY:
+            return 'rate(365 days)'
+        return f"cron({self.value})"
+
+    @property
+    def k8s(self) -> str:
+        """
+        The schedule in terms Kubernetes CronJobs expects.
+
+        For more details, see:
+
+        https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+        """
+
+        return self.value

--- a/scheduling.py
+++ b/scheduling.py
@@ -10,10 +10,10 @@ class Schedule(Enum):
     """
 
     # Daily at around midnight EST.
-    DAILY = "0 5 * * ? *"
+    DAILY = "0 5 * * ?"
 
     # Every other day around midnight EST.
-    EVERY_OTHER_DAY = '0 5 */2 * ? *'
+    EVERY_OTHER_DAY = '0 5 */2 * ?'
 
     # Once per year.
     YEARLY = "@yearly"
@@ -32,7 +32,8 @@ class Schedule(Enum):
 
         if self == Schedule.YEARLY:
             return 'rate(365 days)'
-        return f"cron({self.value})"
+        # Note the additional "*"; AWS has a sixth field that is the year.
+        return f"cron({self.value} *)"
 
     @property
     def k8s(self) -> str:

--- a/tests/test_aws_schedule_tasks.py
+++ b/tests/test_aws_schedule_tasks.py
@@ -1,10 +1,6 @@
 import aws_schedule_tasks
 
 
-def test_sanity_check_works():
-    aws_schedule_tasks.sanity_check()
-
-
 def test_create_input_str_works():
     s = aws_schedule_tasks.create_input_str('foo', 'boop', True)
     assert 'foo' in s

--- a/tests/test_k8s_build_jobs.py
+++ b/tests/test_k8s_build_jobs.py
@@ -7,5 +7,5 @@ import k8s_build_jobs
 def test_build_jobs_works():
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmp = Path(tmpdirname)
-        k8s_build_jobs.main(tmp)
+        k8s_build_jobs.main(['--jobs-dir', tmpdirname])
         assert (tmp / 'load_dataset_hpd_registrations.yml').exists()

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -13,8 +13,8 @@ def test_aws_works(value, expected):
 
 
 @pytest.mark.parametrize('value,expected', [
-    (Schedule.DAILY, "0 5 * * ? *"),
-    (Schedule.EVERY_OTHER_DAY, "0 5 */2 * ? *"),
+    (Schedule.DAILY, "0 5 * * ?"),
+    (Schedule.EVERY_OTHER_DAY, "0 5 */2 * ?"),
     (Schedule.YEARLY, "@yearly"),
 ])
 def test_k8s_works(value, expected):

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,0 +1,21 @@
+import pytest
+
+from scheduling import Schedule
+
+
+@pytest.mark.parametrize('value,expected', [
+    (Schedule.DAILY, "cron(0 5 * * ? *)"),
+    (Schedule.EVERY_OTHER_DAY, "cron(0 5 */2 * ? *)"),
+    (Schedule.YEARLY, "rate(365 days)"),
+])
+def test_aws_works(value, expected):
+    assert value.aws == expected
+
+
+@pytest.mark.parametrize('value,expected', [
+    (Schedule.DAILY, "0 5 * * ? *"),
+    (Schedule.EVERY_OTHER_DAY, "0 5 */2 * ? *"),
+    (Schedule.YEARLY, "@yearly"),
+])
+def test_k8s_works(value, expected):
+    assert value.k8s == expected


### PR DESCRIPTION
This updates the `k8s_build_jobs.py` script to work again, and updates its documentation.