### PR TITLE
Use python 3.6.14.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6 AS base
+FROM python:3.6.14 AS base
 
 RUN apt-get update && \
   apt-get install -y \


### PR DESCRIPTION
This pins us to Python 3.6.14.

I don't know what's going on, but running `docker run --rm justfixnyc/nycdb-k8s-loader:latest` prints no output, when it should in fact display a traceback with `KeyError: 'DATABASE_URL'` at the end.  Pinning us to Python 3.6.14 might make CircleCI at least regenerate the Docker image in a way that might make things work again, but I have no idea.