### PR TITLE
Generate WoW portfolio graphs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,16 @@ RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && rm wow.zip \
   && mv who-owns-what-${WOW_REV} who-owns-what
 
+# This is kind of terrible. We've got a package in WoW that
+# generates our portfolio graphs, but it's not really made
+# for distribution right now (e.g. it has no `setup.py` or
+# formal list of dependencies). So here we're just "hacking"
+# it into our Python installation and manually installing its
+# dependencies, at least until we formally turn it into a
+# real Python package.
+RUN ln -s /who-owns-what/portfoliograph /usr/local/lib/python3.6/site-packages/portfoliograph && \
+  pip install networkx==2.5.1
+
 ENV PYTHONUNBUFFERED yup
 
 # Note that these won't actually work until we either mount /app as a

--- a/wowutil.py
+++ b/wowutil.py
@@ -63,6 +63,13 @@ def install_db_extensions(conn):
     conn.commit()
 
 
+def populate_portfolios_table(conn):
+    import portfoliograph.table
+
+    portfoliograph.table.populate_portfolios_table(conn)
+    conn.commit()
+
+
 def build(db_url: str):
     slack.sendmsg('Rebuilding Who Owns What tables...')
 
@@ -78,6 +85,7 @@ def build(db_url: str):
         temp_schema = create_temp_schema_name(cosmetic_dataset_name)
         with create_and_enter_temporary_schema(conn, temp_schema):
             run_wow_sql(conn)
+            populate_portfolios_table(conn)
             ensure_schema_exists(conn, WOW_SCHEMA)
             with save_and_reapply_permissions(conn, tables, WOW_SCHEMA):
                 drop_tables_if_they_exist(conn, tables, WOW_SCHEMA)


### PR DESCRIPTION
Oy.  #79 didn't do what we wanted--it only made an _empty_ table for WoW portfolio graphs--because nycdb-k8s-loader doesn't actually run any of WoW's python code.  It only goes through WoW's `who-owns-what.yml`, extracts its list of SQL files and runs them.  This was done back in the day because WoW itself isn't really a Python package the way that nycdb is (and turning it into one isn't particularly easy since it includes lots of dependencies that nycdb-k8s-loader doesn't actually need, like Django).

So this is a terrible hack that installs just enough dependencies (networkx) for WoW's `portfoliograph` package to run, and then uses it to populate the WoW portfolio graphs table.

It is not awesome.  But it should hopefully make nycdb-k8s-loader actually populate the portfolio graphs table.