### PR TITLE
Update WOW_REV to incorporate new 2020 RS data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=0589da794ccc2203eceddea6c92db34924a67251
+ARG WOW_REV=3f95e163ebbdb816e4683be5f995abf0f004add1
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR updates our reference to the Who Owns What codebase so that we can reference the updated SQL files in JustFixNYC/who-owns-what#534 in our auto-updating instance of nycdb.