### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ is essentially a shortcut for `wowutil.py build` and can be
 a convenient way to "slot in" the loading of WoW data to an
 already existing workflow for other NYCDB datasets.
 
+At the time of this update, there is a [custom scheduled ECS rule][]
+created via the AWS console that updates the `wow` dataset.
+
 [Cron Jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 [NYC-DB]: https://github.com/aepyornis/nyc-db
 [Kubernetes Jobs]: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
@@ -242,3 +245,4 @@ already existing workflow for other NYCDB datasets.
 [Postgres schema]: https://www.postgresql.org/docs/9.5/ddl-schemas.html
 [Who Owns What]: https://github.com/justfixnyc/who-owns-what
 [Postgres schema search path]: https://www.postgresql.org/docs/9.6/ddl-schemas.html#DDL-SCHEMAS-PATH
+[custom scheduled ECS rule]: https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/atul-default/scheduledTasks/custom-load-wow


### PR DESCRIPTION
[ch7092]

Updates the readme. 
This should also trigger the config.yml rule to regenerate the scheduled tasks using the new task definition, which we need it to do so we can update the name of the db cluster from atul-experimenting to the more prod-y nyc-db.cluster-custom-ckvyf7p6u5rl.us-east-1.rds.amazonaws.com and frees us up to change the atul-experimenting name.