### PR TITLE
Update WOW_REV to incorporate new wow_portfolios generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=88660818f40ee1ae0467a28f6ea6a1b0ff1b1377
+ARG WOW_REV=0ec2244bc8311ab34e1b3e12da9663b9cc1c4013
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
This PR updates our reference to the Who Owns What codebase so that we can reference the updated SQL code that generates the `wow_portfolios` table.