### PR TITLE
Bump ubuntu version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202201-02
     environment:
       CLUSTER_NAME: atul-default
       AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
[sc-8637]

In response to this email:
--------------------------
```
Hello,

We are deprecating Ubuntu 16.04-based machine images on CircleCI in preparation for an EOL on Tuesday, May 31, 2022 to ensure your builds remain secure. For a detailed overview of how this will affect your workflow, read the blog article here.

We will also be conducting temporary brownouts on Tuesday, March 29, 2022, and again on Tuesday, April 26, 2022 during which these images will be unavailable.

We are contacting you because one or more of your projects has a job that uses an Ubuntu 16.04-based image.

The project(s) using an image based on Ubuntu 16.04 are:
[nycdb-k8s-loader]

If you have specified an Ubuntu 16.04-based image please see our migration guide to upgrade to a newer version of Ubuntu image in order to avoid any service disruption during the brownout & subsequent EOL.

We will also be releasing a CircleCI Ubuntu 22.04 image on April 22nd offering the flexibility to upgrade to the latest LTS version of Ubuntu image before we remove older versions permanently. A beta version of the image will be available March 21st.

https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/?mkt_tok=NDg1LVpNSC02MjYAAAGCndZe0VLrWoxgVPv3Ug4trMTE7CBiUROVYlVXmeBLjHuL_oYzzM6gVLFSyeAgd5pVMb2SZo8EvwjrIIL8svIWk3qxNc4ienCiAXf8i_KzPss

```