### PR TITLE
Figure out which NYCDB_REV started making the Circle CI test time out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=5357f57a36595349eaf3d554b4c5418fe9d73c97
+ARG NYCDB_REV=65174c67704435c5383405665ac7574d183fcd17
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=065a32205ada7070d89e2cd4be32963bcf487a4c
+ARG NYCDB_REV=ac377e5e6bfba0235fe8ada8f83d0f5d47256e63
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=0aadc749a140ce209d7d6f10c2003b3f8e981c10
+ARG NYCDB_REV=694d2b52e731bcd6bd9e05862281afa205701fa9
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=ac377e5e6bfba0235fe8ada8f83d0f5d47256e63
+ARG NYCDB_REV=065a32205ada7070d89e2cd4be32963bcf487a4c
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=694d2b52e731bcd6bd9e05862281afa205701fa9
+ARG NYCDB_REV=7c073a75c430067d7a9ed578a77f2a4c0b3514b9
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=65174c67704435c5383405665ac7574d183fcd17
+ARG NYCDB_REV=fd5d3b3fcc431f2eff8cc7360f5aca95b144b31b
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=27db1d7aad83408a104013ff79eec9c76540f98e
+ARG NYCDB_REV=065a32205ada7070d89e2cd4be32963bcf487a4c
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=7c073a75c430067d7a9ed578a77f2a4c0b3514b9
+ARG NYCDB_REV=5357f57a36595349eaf3d554b4c5418fe9d73c97
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=fd5d3b3fcc431f2eff8cc7360f5aca95b144b31b
+ARG NYCDB_REV=27db1d7aad83408a104013ff79eec9c76540f98e
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=ac377e5e6bfba0235fe8ada8f83d0f5d47256e63
+ARG NYCDB_REV=0aadc749a140ce209d7d6f10c2003b3f8e981c10
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
https://github.com/JustFixNYC/nycdb-k8s-loader/pull/96 is not passing CircleCI tests bc one of its test suites is timing out... this PR is attempting to diagnose which commit to the nycdb codebase is making the test suite fail:

- https://github.com/nycdb/nycdb/commit/0aadc749a140ce209d7d6f10c2003b3f8e981c10 FAILS
- https://github.com/nycdb/nycdb/commit/694d2b52e731bcd6bd9e05862281afa205701fa9 FAILS
- https://github.com/nycdb/nycdb/commit/7c073a75c430067d7a9ed578a77f2a4c0b3514b9 FAILS
- https://github.com/nycdb/nycdb/commit/5357f57a36595349eaf3d554b4c5418fe9d73c97 FAILS
- https://github.com/nycdb/nycdb/commit/65174c67704435c5383405665ac7574d183fcd17 FAILS
- Skipping `f98d115baa69630769d14af67a9af728c6f5f9ef` since it's just a change to the README
- https://github.com/nycdb/nycdb/commit/fd5d3b3fcc431f2eff8cc7360f5aca95b144b31b FAILS
- Skipping a few commits...
- https://github.com/nycdb/nycdb/commit/27db1d7aad83408a104013ff79eec9c76540f98e FAILS
- https://github.com/nycdb/nycdb/commit/065a32205ada7070d89e2cd4be32963bcf487a4c FAILS
- https://github.com/nycdb/nycdb/commit/ac377e5e6bfba0235fe8ada8f83d0f5d47256e63 PASSED