### PR TITLE
When testing edit Dataset files to match available test data

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -23,11 +23,11 @@ from lib.dbhash import SqlDbHash
 
 
 MY_DIR = Path(__file__).parent.resolve()
-NYCDB_DIR = Path('/nycdb/src')
-TEST_DATA_DIR = NYCDB_DIR / 'tests' / 'integration' / 'data'
-NYCDB_DATA_DIR = Path('/var/nycdb')
+NYCDB_DIR = Path("/nycdb/src")
+TEST_DATA_DIR = NYCDB_DIR / "tests" / "integration" / "data"
+NYCDB_DATA_DIR = Path("/var/nycdb")
 
-ROLLBAR_ACCESS_TOKEN = os.environ.get('ROLLBAR_ACCESS_TOKEN', '')
+ROLLBAR_ACCESS_TOKEN = os.environ.get("ROLLBAR_ACCESS_TOKEN", "")
 
 
 class CommandError(Exception):
@@ -37,8 +37,8 @@ class CommandError(Exception):
 
 
 class Config(NamedTuple):
-    database_url: str = os.environ['DATABASE_URL']
-    use_test_data: bool = bool(os.environ.get('USE_TEST_DATA', ''))
+    database_url: str = os.environ["DATABASE_URL"]
+    use_test_data: bool = bool(os.environ.get("USE_TEST_DATA", ""))
 
     @property
     def nycdb_args(self):
@@ -66,16 +66,16 @@ class TableInfo(NamedTuple):
 
 
 def create_temp_schema_name(dataset: str) -> str:
-    return f'{get_temp_schema_prefix(dataset)}{int(time.time())}'
+    return f"{get_temp_schema_prefix(dataset)}{int(time.time())}"
 
 
 def get_temp_schema_prefix(dataset: str) -> str:
-    return f'temp_{dataset}_'
+    return f"temp_{dataset}_"
 
 
 def get_friendly_temp_schema_creation_time(name: str) -> str:
-    t = time.gmtime(int(name.split('_')[-1]))
-    return time.strftime('%Y-%m-%d %H:%M:%S', t) + ' UTC'
+    t = time.gmtime(int(name.split("_")[-1]))
+    return time.strftime("%Y-%m-%d %H:%M:%S", t) + " UTC"
 
 
 def get_temp_schemas(conn, dataset: str) -> List[str]:
@@ -91,38 +91,35 @@ def get_temp_schemas(conn, dataset: str) -> List[str]:
 def get_dataset_tables() -> List[TableInfo]:
     result: List[TableInfo] = []
     for dataset_name, info in nycdb.dataset.datasets().items():
-        for schema in list_wrap(info['schema']):
-            result.append(TableInfo(name=schema['table_name'], dataset=dataset_name))
-        result.extend([
-            TableInfo(name=name, dataset=dataset_name)
-            for name in parse_nycdb_created_tables(info.get('sql', []))
-        ])
+        for schema in list_wrap(info["schema"]):
+            result.append(TableInfo(name=schema["table_name"], dataset=dataset_name))
+        result.extend(
+            [
+                TableInfo(name=name, dataset=dataset_name)
+                for name in parse_nycdb_created_tables(info.get("sql", []))
+            ]
+        )
     return result
 
 
 def get_tables_for_dataset(dataset: str) -> List[TableInfo]:
-    tables = [
-        table for table in get_dataset_tables()
-        if table.dataset == dataset
-    ]
+    tables = [table for table in get_dataset_tables() if table.dataset == dataset]
     if not tables:
         raise CommandError(f"'{dataset}' is not a valid dataset.")
     return tables
 
 
 def get_urls_for_dataset(dataset: str) -> List[str]:
-    return [
-        fileinfo['url'] for fileinfo in nycdb.dataset.datasets()[dataset]['files']
-    ]
+    return [fileinfo["url"] for fileinfo in nycdb.dataset.datasets()[dataset]["files"]]
 
 
 def get_all_create_function_sql(root_dir: Path, sql_files: List[str]) -> str:
-    '''
+    """
     Given the SQL files in the given root directory, concatenate the
     contents of only the ones that contain "CREATE OR REPLACE FUNCTION"
     SQL statements. It's assumed that these particular SQL files are
     idempotent.
-    '''
+    """
 
     sqls: List[str] = []
 
@@ -131,17 +128,17 @@ def get_all_create_function_sql(root_dir: Path, sql_files: List[str]) -> str:
         if does_sql_create_functions(sql):
             sqls.append(sql)
 
-    return '\n'.join(sqls)
+    return "\n".join(sqls)
 
 
 def get_all_create_function_sql_for_dataset(dataset: str) -> str:
     return get_all_create_function_sql(
-        root_dir=Path(nycdb.__file__).parent.resolve() / 'sql',
-        sql_files=nycdb.dataset.datasets()[dataset].get('sql', [])
+        root_dir=Path(nycdb.__file__).parent.resolve() / "sql",
+        sql_files=nycdb.dataset.datasets()[dataset].get("sql", []),
     )
 
 
-def run_sql_if_nonempty(conn, sql: str, initial_sql: str = ''):
+def run_sql_if_nonempty(conn, sql: str, initial_sql: str = ""):
     if sql:
         with conn.cursor() as cur:
             if initial_sql:
@@ -151,11 +148,11 @@ def run_sql_if_nonempty(conn, sql: str, initial_sql: str = ''):
 
 
 def collapse_whitespace(text: str) -> str:
-    return re.sub(r'\W+', ' ', text)
+    return re.sub(r"\W+", " ", text)
 
 
 def does_sql_create_functions(sql: str) -> bool:
-    return 'CREATE OR REPLACE FUNCTION' in collapse_whitespace(sql).upper()
+    return "CREATE OR REPLACE FUNCTION" in collapse_whitespace(sql).upper()
 
 
 def drop_tables_if_they_exist(conn, tables: List[TableInfo], schema: str):
@@ -169,25 +166,25 @@ def drop_tables_if_they_exist(conn, tables: List[TableInfo], schema: str):
 
 @contextlib.contextmanager
 def save_and_reapply_permissions(conn, tables: List[TableInfo], schema: str):
-    '''
+    """
     Holy hell this is annoying. See this issue for details:
     https://github.com/JustFixNYC/nycdb-k8s-loader/issues/5
-    '''
+    """
 
     # Create blank placeholder tables if they don't already exist,
     # so that any users with default privileges in our schema
     # have expected permissions on them.
-    create_blank_tables = ';'.join([
-        f'CREATE TABLE IF NOT EXISTS {schema}.{table.name} ()'
-        for table in tables
-    ])
+    create_blank_tables = ";".join(
+        [f"CREATE TABLE IF NOT EXISTS {schema}.{table.name} ()" for table in tables]
+    )
     with conn.cursor() as cur:
         cur.execute(create_blank_tables)
     conn.commit()
 
     # Now remember the permissions on the tables.
-    grants = ''.join(db_perms.get_grant_sql(conn, table.name, schema)
-                     for table in tables)
+    grants = "".join(
+        db_perms.get_grant_sql(conn, table.name, schema) for table in tables
+    )
 
     # Let the code inside our "with" clause run. It will likely
     # drop the tables and replace them with new ones that have
@@ -208,14 +205,18 @@ def ensure_schema_exists(conn, schema: str):
 def create_and_enter_temporary_schema(conn, schema: str):
     print(f"Creating and entering temporary schema '{schema}'.")
     with conn.cursor() as cur:
-         cur.execute('; '.join([
-             f"DROP SCHEMA IF EXISTS {schema} CASCADE",
-             f"CREATE SCHEMA {schema}",
-             # Note that we still need public at the end of the search
-             # path since we want functions like first(), which are
-             # declared in the public schema, to work.
-             f"SET search_path TO {schema}, public"
-         ]))
+        cur.execute(
+            "; ".join(
+                [
+                    f"DROP SCHEMA IF EXISTS {schema} CASCADE",
+                    f"CREATE SCHEMA {schema}",
+                    # Note that we still need public at the end of the search
+                    # path since we want functions like first(), which are
+                    # declared in the public schema, to work.
+                    f"SET search_path TO {schema}, public",
+                ]
+            )
+        )
     conn.commit()
 
     try:
@@ -226,14 +227,17 @@ def create_and_enter_temporary_schema(conn, schema: str):
     finally:
         print(f"Destroying temporary schema '{schema}'.")
         with conn.cursor() as cur:
-            cur.execute('; '.join([
-                f'DROP SCHEMA {schema} CASCADE',
-                f'SET search_path TO public'
-            ]))
+            cur.execute(
+                "; ".join(
+                    [f"DROP SCHEMA {schema} CASCADE", f"SET search_path TO public"]
+                )
+            )
         conn.commit()
 
 
-def change_table_schemas(conn, tables: List[TableInfo], from_schema: str, to_schema: str):
+def change_table_schemas(
+    conn, tables: List[TableInfo], from_schema: str, to_schema: str
+):
     with conn.cursor() as cur:
         for table in tables:
             name = f"{from_schema}.{table.name}"
@@ -247,21 +251,24 @@ def sanity_check():
 
 
 def get_dbhash(conn) -> SqlDbHash:
-    ensure_schema_exists(conn, 'nycdb_k8s_loader')
-    return SqlDbHash(conn, 'nycdb_k8s_loader.dbhash')
+    ensure_schema_exists(conn, "nycdb_k8s_loader")
+    return SqlDbHash(conn, "nycdb_k8s_loader.dbhash")
 
 
-def load_dataset(dataset: str, config: Config=Config(), force_check_urls: bool=False):
-    '''
+def load_dataset(
+    dataset: str, config: Config = Config(), force_check_urls: bool = False
+):
+    """
     Load the given dataset using the given configuration.
 
     Note that `force_check_urls` is only used by the test suite. This is a
     bad code smell, but unfortunately it was the easiest way to test the URL-checking
     functionality with test data.
-    '''
+    """
 
-    if dataset == 'wow':
+    if dataset == "wow":
         import wowutil
+
         wowutil.build(config.database_url)
         return
 
@@ -275,19 +282,23 @@ def load_dataset(dataset: str, config: Config=Config(), force_check_urls: bool=F
 
     check_urls = (not config.use_test_data) or force_check_urls
     if check_urls and not modtracker.did_any_urls_change():
-        slack.sendmsg(f'The dataset `{dataset}` has not changed since we last retrieved it.')
+        slack.sendmsg(
+            f"The dataset `{dataset}` has not changed since we last retrieved it."
+        )
         return
 
-    slack.sendmsg(f'Downloading the dataset `{dataset}`...')
+    slack.sendmsg(f"Downloading the dataset `{dataset}`...")
     ds.download_files()
 
-    slack.sendmsg(f'Downloaded the dataset `{dataset}`. Loading it into the database...')
+    slack.sendmsg(
+        f"Downloaded the dataset `{dataset}`. Loading it into the database..."
+    )
     temp_schema = create_temp_schema_name(dataset)
     with create_and_enter_temporary_schema(conn, temp_schema):
         ds.db_import()
-        with save_and_reapply_permissions(conn, tables, 'public'):
-            drop_tables_if_they_exist(conn, tables, 'public')
-            change_table_schemas(conn, tables, temp_schema, 'public')
+        with save_and_reapply_permissions(conn, tables, "public"):
+            drop_tables_if_they_exist(conn, tables, "public")
+            change_table_schemas(conn, tables, temp_schema, "public")
 
     # The dataset's tables are ready, but any functions defined by the
     # dataset's custom SQL were in the temporary schema that just got
@@ -296,7 +307,7 @@ def load_dataset(dataset: str, config: Config=Config(), force_check_urls: bool=F
     run_sql_if_nonempty(conn, get_all_create_function_sql_for_dataset(dataset))
 
     modtracker.update_lastmods()
-    slack.sendmsg(f'Finished loading the dataset `{dataset}` into the database.')
+    slack.sendmsg(f"Finished loading the dataset `{dataset}` into the database.")
     print("Success!")
 
 
@@ -305,9 +316,9 @@ def init_rollbar():
         print("Initializing Rollbar.")
         rollbar.init(
             access_token=ROLLBAR_ACCESS_TOKEN,
-            environment='production',
+            environment="production",
             root=str(MY_DIR),
-            handler='blocking',
+            handler="blocking",
         )
 
 
@@ -318,10 +329,10 @@ def error_handling(dataset: str):
         yield
     except Exception as e:
         if ROLLBAR_ACCESS_TOKEN:
-            rollbar.report_exc_info(extra_data={'dataset': dataset})
+            rollbar.report_exc_info(extra_data={"dataset": dataset})
         slack.sendmsg(
             f"Alas, an error occurred when loading the dataset `{dataset}`.",
-            stdout=not isinstance(e, CommandError)
+            stdout=not isinstance(e, CommandError),
         )
         if isinstance(e, CommandError):
             print(e.message)
@@ -330,8 +341,8 @@ def error_handling(dataset: str):
             raise
 
 
-def main(argv: List[str]=sys.argv):
-    dataset = os.environ.get('DATASET', '')
+def main(argv: List[str] = sys.argv):
+    dataset = os.environ.get("DATASET", "")
 
     if len(argv) > 1:
         dataset = argv[1]
@@ -349,5 +360,5 @@ def main(argv: List[str]=sys.argv):
         load_dataset(dataset)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -10,14 +10,15 @@ from load_dataset import (
     CommandError,
     does_sql_create_functions,
     get_all_create_function_sql_for_dataset,
-    collapse_whitespace,
+    collapse_whitespace
 )
 import dbtool
 
 
 def test_get_dataset_tables_included_derived_tables():
     info = load_dataset.TableInfo(
-        name="hpd_registrations_grouped_by_bbl", dataset="hpd_registrations"
+        name='hpd_registrations_grouped_by_bbl',
+        dataset='hpd_registrations'
     )
     assert info in load_dataset.get_dataset_tables()
 
@@ -28,22 +29,24 @@ def get_row_counts(conn, dataset: str) -> Dict[str, int]:
 
 
 def test_get_urls_for_dataset_works():
-    urls = load_dataset.get_urls_for_dataset("hpd_registrations")
+    urls = load_dataset.get_urls_for_dataset('hpd_registrations')
     assert len(urls) > 0
     for url in urls:
-        assert url.startswith("https://")
+        assert url.startswith('https://')
 
 
 def run_dataset_specific_test_logic(conn, dataset):
-    if dataset == "hpd_registrations":
+    if dataset == 'hpd_registrations':
         with conn.cursor() as cur:
             # Make sure the function defined by the dataset's SQL scripts exists.
-            cur.execute("SELECT get_corporate_owner_info_for_regid(1)")
+            cur.execute('SELECT get_corporate_owner_info_for_regid(1)')
 
 
-@pytest.mark.parametrize("dataset", nycdb.dataset.datasets().keys())
+@pytest.mark.parametrize('dataset', nycdb.dataset.datasets().keys())
 def test_load_dataset_works(test_db_env, dataset):
-    subprocess.check_call(["python", "load_dataset.py", dataset], env=test_db_env)
+    subprocess.check_call([
+        'python', 'load_dataset.py', dataset
+    ], env=test_db_env)
 
     with make_conn() as conn:
         run_dataset_specific_test_logic(conn, dataset)
@@ -55,7 +58,9 @@ def test_load_dataset_works(test_db_env, dataset):
 
     # Ensure idempotency.
 
-    subprocess.check_call(["python", "load_dataset.py", dataset], env=test_db_env)
+    subprocess.check_call([
+        'python', 'load_dataset.py', dataset
+    ], env=test_db_env)
 
     with make_conn() as conn:
         run_dataset_specific_test_logic(conn, dataset)
@@ -64,78 +69,78 @@ def test_load_dataset_works(test_db_env, dataset):
 
 def test_load_dataset_fails_if_no_dataset_provided(test_db_env):
     with pytest.raises(subprocess.CalledProcessError):
-        subprocess.check_call(["python", "load_dataset.py"], env=test_db_env)
+        subprocess.check_call([
+            'python', 'load_dataset.py'
+        ], env=test_db_env)
 
 
 def test_get_tables_for_dataset_raises_error_on_invalid_dataset():
     with pytest.raises(CommandError):
-        load_dataset.get_tables_for_dataset("blarg")
+        load_dataset.get_tables_for_dataset('blarg')
 
 
 def test_temp_schema_naming_works():
-    with patch("time.time", return_value=1545146760.1446786):
-        name = load_dataset.create_temp_schema_name("boop")
-        assert name == "temp_boop_1545146760"
+    with patch('time.time', return_value=1545146760.1446786):
+        name = load_dataset.create_temp_schema_name('boop')
+        assert name == 'temp_boop_1545146760'
         ts = load_dataset.get_friendly_temp_schema_creation_time(name)
-        assert ts == "2018-12-18 15:26:00 UTC"
+        assert ts == '2018-12-18 15:26:00 UTC'
 
 
 def test_get_temp_schemas_works(test_db_env, conn):
-    with patch("time.time", return_value=1234.1446786):
-        schema = load_dataset.create_temp_schema_name("boop")
+    with patch('time.time', return_value=1234.1446786):
+        schema = load_dataset.create_temp_schema_name('boop')
         with load_dataset.create_and_enter_temporary_schema(conn, schema):
-            assert load_dataset.get_temp_schemas(conn, "boop") == ["temp_boop_1234"]
-        assert len(load_dataset.get_temp_schemas(conn, "boop")) == 0
+            assert load_dataset.get_temp_schemas(conn, 'boop') == [
+                'temp_boop_1234'
+            ]
+        assert len(load_dataset.get_temp_schemas(conn, 'boop')) == 0
 
 
 def test_exceptions_send_slack_msg(slack_outbox):
-    with patch.object(load_dataset, "load_dataset") as load:
-        load.side_effect = Exception("blah")
-        with pytest.raises(Exception, match="blah"):
-            load_dataset.main(["", "hpd_registrations"])
-        load.assert_called_once_with("hpd_registrations")
+    with patch.object(load_dataset, 'load_dataset') as load:
+        load.side_effect = Exception('blah')
+        with pytest.raises(Exception, match='blah'):
+            load_dataset.main(['', 'hpd_registrations'])
+        load.assert_called_once_with('hpd_registrations')
         assert slack_outbox == [
-            "Alas, an error occurred when loading the dataset `hpd_registrations`."
+            'Alas, an error occurred when loading the dataset `hpd_registrations`.'
         ]
 
 
 def test_unmodified_datasets_are_not_retrieved(db, requests_mock, slack_outbox):
-    urls = load_dataset.get_urls_for_dataset("hpd_registrations")
+    urls = load_dataset.get_urls_for_dataset('hpd_registrations')
     config = load_dataset.Config(database_url=DATABASE_URL, use_test_data=True)
-    load = lambda: load_dataset.load_dataset(
-        "hpd_registrations", config, force_check_urls=True
-    )
+    load = lambda: load_dataset.load_dataset('hpd_registrations', config, force_check_urls=True)
 
     for url in urls:
-        requests_mock.get(url, text="blah", headers={"ETag": "blah"})
+        requests_mock.get(url, text='blah', headers={'ETag': 'blah'})
 
     load()
-    assert slack_outbox[0] == "Downloading the dataset `hpd_registrations`..."
+    assert slack_outbox[0] == 'Downloading the dataset `hpd_registrations`...'
     slack_outbox[:] = []
 
     for url in urls:
-        requests_mock.get(
-            url, request_headers={"If-None-Match": "blah"}, status_code=304
-        )
+        requests_mock.get(url, request_headers={'If-None-Match': 'blah'}, status_code=304)
     load()
     assert slack_outbox == [
-        "The dataset `hpd_registrations` has not changed since we last retrieved it."
+        'The dataset `hpd_registrations` has not changed since we last retrieved it.'
     ]
     slack_outbox[:] = []
 
     for url in urls:
-        requests_mock.get(url, text="blah2", headers={"ETag": "blah2"})
+        requests_mock.get(url, text='blah2', headers={'ETag': 'blah2'})
     load()
-    assert slack_outbox[0] == "Downloading the dataset `hpd_registrations`..."
+    assert slack_outbox[0] == 'Downloading the dataset `hpd_registrations`...'
 
 
 def test_does_sql_create_functions_works():
-    assert does_sql_create_functions("\nCREATE OR REPLACE FUNCTION boop()") is True
-    assert does_sql_create_functions("CREATE OR  REPLACE  \nFUNCTION boop()") is True
-    assert does_sql_create_functions("create or  replace  \nfunction boop()") is True
-    assert does_sql_create_functions("CREATE OR ZZZ REPLACE FUNCTION boop()") is False
-    assert does_sql_create_functions("") is False
-    assert does_sql_create_functions("CREATE TABLE blarg") is False
+    assert does_sql_create_functions('\nCREATE OR REPLACE FUNCTION boop()') is True
+    assert does_sql_create_functions('CREATE OR  REPLACE  \nFUNCTION boop()') is True
+    assert does_sql_create_functions('create or  replace  \nfunction boop()') is True
+    assert does_sql_create_functions('CREATE OR ZZZ REPLACE FUNCTION boop()') is False
+    assert does_sql_create_functions('') is False
+    assert does_sql_create_functions('CREATE TABLE blarg') is False
 
 
 def test_get_all_create_function_sql_for_dataset_conforms_to_expectations():
@@ -143,9 +148,9 @@ def test_get_all_create_function_sql_for_dataset_conforms_to_expectations():
         # Make sure that all the SQL that creates functions *only* creates
         # functions and doesn't e.g. create tables.
         sql = get_all_create_function_sql_for_dataset(dataset)
-        assert "CREATE TABLE" not in collapse_whitespace(sql).upper()
+        assert 'CREATE TABLE' not in collapse_whitespace(sql).upper()
 
 
 def test_get_all_create_function_sql_for_dataset_works():
-    sql = get_all_create_function_sql_for_dataset("hpd_registrations")
-    assert "CREATE OR REPLACE FUNCTION get_corporate_owner_info_for_regid" in sql
+    sql = get_all_create_function_sql_for_dataset('hpd_registrations')
+    assert 'CREATE OR REPLACE FUNCTION get_corporate_owner_info_for_regid' in sql


### PR DESCRIPTION
Two new datasets recently added to NYCDB (`dof_annual_sales` and `dof_421a`) include a very large number of individual files, but in the test data only a couple of them are included and [manually edited](https://github.com/nycdb/nycdb/blob/main/src/tests/integration/test_nycdb.py#L493-L502) during tests. This creates a problem for nycdb-k8s-loader because it assumes all files are present in the test data. When some test files aren't found during tests for `load_dataset.py` nycdb tries to download and load all the missing files, causing tests to timeout. 

This PR tries to solve this issue by adapting `load_dataset` so that when it's being run in tests the `Dataset`'s files are manually edited to match those available in test data. It doesn't seem ideal to add more test-specific logic to the main function, and to have a section that will need to be added to if more datasets follow this pattern. However, the alternative would mean replacing this nice concise [parameterized test](https://github.com/JustFixNYC/nycdb-k8s-loader/blob/main/tests/test_load_dataset.py#L45-L67) of all the datasets with something more complicated that wouldn't be as directly testing the full `load_dataset` function. I'm totally happy to go that route instead if it's preferable, but since this was a much quicker fix I thought I'd offer this option first. 

side note: all the black formatting changes clutter the meaningful changes, so I did that first as a separate commit, but let me know if there is a better way to handle that (separate PR just applying black to the whole project first?)

[sc-8872]