### PR TITLE
Update nycdb to most recent git REV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=27db1d7aad83408a104013ff79eec9c76540f98e
+ARG NYCDB_REV=34d1bf7b9a630d987b1f18cf02b78004df1e3aa0
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
This PR makes sure our k8s loader uses the most up-to-date version of nycdb, specifically, this one: https://github.com/nycdb/nycdb/commit/34d1bf7b9a630d987b1f18cf02b78004df1e3aa0