### PR TITLE
add wow schema to search path when in temp schema

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -212,8 +212,9 @@ def create_and_enter_temporary_schema(conn, schema: str):
                     f"CREATE SCHEMA {schema}",
                     # Note that we still need public at the end of the search
                     # path since we want functions like first(), which are
-                    # declared in the public schema, to work.
-                    f"SET search_path TO {schema}, public",
+                    # declared in the public schema, to work. And we need wow
+                    # because the OCA tables are in that schema.
+                    f"SET search_path TO {schema}, public, wow",
                 ]
             )
         )


### PR DESCRIPTION
This PR adds `wow` to the search_path used when in the temp schema. This is because when creating `wow_bldgs` we need access to `wow.oca_evictions_bldgs`. I think this option is easier than to put the explicit `wow.` prefix in the query because that complicates everything is testing where all the schemas don't work the same way. 