### PR TITLE
put oca tables in own schema

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -212,9 +212,9 @@ def create_and_enter_temporary_schema(conn, schema: str):
                     f"CREATE SCHEMA {schema}",
                     # Note that we still need public at the end of the search
                     # path since we want functions like first(), which are
-                    # declared in the public schema, to work. And we need wow
-                    # because the OCA tables are in that schema.
-                    f"SET search_path TO {schema}, public, wow",
+                    # declared in the public schema, to work. And we need oca
+                    # because those tables are used for wow_bldgs.
+                    f"SET search_path TO {schema}, public, oca",
                 ]
             )
         )

--- a/ocautil.py
+++ b/ocautil.py
@@ -16,12 +16,10 @@ Environment variables:
 
 import os
 import sys
-from pathlib import Path
 from typing import List
 
 import docopt
 import psycopg2
-import yaml
 
 from lib import slack
 from load_dataset import (
@@ -35,15 +33,9 @@ from load_dataset import (
     NYCDB_DATA_DIR,
     TEST_DATA_DIR,
 )
-from wowutil import install_db_extensions
+from wowutil import WOW_SQL_DIR, WOW_YML, install_db_extensions
 
-WOW_SCHEMA = "wow"
-
-WOW_DIR = Path("/who-owns-what")
-
-WOW_SQL_DIR = Path(WOW_DIR / "sql")
-
-WOW_YML = yaml.load((WOW_DIR / "who-owns-what.yml").read_text(), Loader=yaml.FullLoader)
+OCA_SCHEMA = "oca"
 
 OCA_TABLES: List[str] = WOW_YML["oca_tables"]
 
@@ -84,10 +76,10 @@ def build(db_url: str, is_testing: bool = False):
         temp_schema = create_temp_schema_name(cosmetic_dataset_name)
         with create_and_enter_temporary_schema(conn, temp_schema):
             create_and_populate_oca_tables(conn, is_testing)
-            ensure_schema_exists(conn, WOW_SCHEMA)
-            with save_and_reapply_permissions(conn, tables, WOW_SCHEMA):
-                drop_tables_if_they_exist(conn, tables, WOW_SCHEMA)
-                change_table_schemas(conn, tables, temp_schema, WOW_SCHEMA)
+            ensure_schema_exists(conn, OCA_SCHEMA)
+            with save_and_reapply_permissions(conn, tables, OCA_SCHEMA):
+                drop_tables_if_they_exist(conn, tables, OCA_SCHEMA)
+                change_table_schemas(conn, tables, temp_schema, OCA_SCHEMA)
 
         # Note that if we ever add SQL functions to the OCA dataset we'll need
         # to implement the same pattern as in wowutil to recreate them in the

--- a/tests/test_ocautil.py
+++ b/tests/test_ocautil.py
@@ -19,7 +19,7 @@ def copy_oca_test_data_to_nycdb_dir():
 def ensure_oca_works():
     with psycopg2.connect(DATABASE_URL) as conn:
         with conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM wow.oca_evictions_bldgs")
+            cur.execute("SELECT COUNT(*) FROM oca.oca_evictions_bldgs")
             assert cur.fetchone()[0] > 0
 
 


### PR DESCRIPTION
This PR makes another attempt to fix the schema issues for the wow dataset. Previously I tried to add ww to the search path when working in the temp schema, but that doesn't work because there are locks on the tables and we don't want it to drop the real wow schema tables when making the temp ones of the same name. Instead, we now create the new oca tables in their own `oca` schema, following the same pattern with temp schema as for wow, and then we add the oca schema to the search path when in the temp schema building wow tables. 