### PR TITLE
add SSH key management to k8s job template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=9ca802f17c2ab93312d42e9ccd7303cd58ce22e9
+ARG WOW_REV=e6c9c8081ccfcc816f237965d65c1e626b457636
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -7,7 +7,16 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+          - name: ssh-keys-v
+            secret:
+              secretName: ssh-keys
+              defaultMode: 0600 
           containers:
           - name: load-dataset
+            volumeMounts:
+            - name: ssh-keys-v
+              readOnly: true
+              mountPath: "/root/.ssh"
           restartPolicy: Never
       backoffLimit: 0


### PR DESCRIPTION
This PR edits the k8s job template for adding datasets to include management of SSH keys so that kubernetes can connect to the private OCA database. The WOW repo rev is also updated bumped to the latest version in the dockerfile.