### PR TITLE
add pluto_latest schedule, update wow_rev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=e6c9c8081ccfcc816f237965d65c1e626b457636
+ARG WOW_REV=3119d14e6471123196237896d66730e1e21227af
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/scheduling.py
+++ b/scheduling.py
@@ -64,6 +64,7 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "dof_sales": Schedule.EVERY_OTHER_DAY,
     "pad": Schedule.EVERY_OTHER_DAY,
     "acris": Schedule.EVERY_OTHER_DAY,
+    "pluto_latest": Schedule.EVERY_OTHER_DAY,
 }
 
 


### PR DESCRIPTION
This PR adds new NYCDB table `pluto_latest` to the scheduling list for every other day, and updates the dockerfile to the latest commit for wow repo. 