### PR TITLE
Update for NYCDB version 0.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=e65c87f872c719edf3a17edddeeae417e1625dc8
+ARG NYCDB_REV=fc70aaa76e9249db8f779a2288f3fd56b81da6cc
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/scheduling.py
+++ b/scheduling.py
@@ -57,6 +57,7 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "oath_hearings": Schedule.DAILY_12AM,
     "marshal_evictions": Schedule.DAILY_12AM,
     "oca_address": Schedule.DAILY_12AM,
+    "hpd_conh": Schedule.DAILY_12AM,
     "wow": Schedule.DAILY_7AM,
     "hpd_vacateorders": Schedule.EVERY_OTHER_DAY,
     "hpd_registrations": Schedule.EVERY_OTHER_DAY,
@@ -65,6 +66,9 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "pad": Schedule.EVERY_OTHER_DAY,
     "acris": Schedule.EVERY_OTHER_DAY,
     "pluto_latest": Schedule.EVERY_OTHER_DAY,
+    "dcp_housingdb": Schedule.EVERY_OTHER_DAY,
+    "speculation_watch_list": Schedule.EVERY_OTHER_DAY,
+    "hpd_affordable_production": Schedule.EVERY_OTHER_DAY,
 }
 
 


### PR DESCRIPTION
Update Dockerfile for latest version of NYCDB (0.2.8), and add schedules for new datasets.

New datasets:
* https://github.com/nycdb/nycdb/pull/235
* https://github.com/nycdb/nycdb/pull/230
* https://github.com/nycdb/nycdb/pull/229
* https://github.com/nycdb/nycdb/pull/227

Also changes to some existing datasets:
* https://github.com/nycdb/nycdb/pull/226 (new column on `pluto_latest`)
* https://github.com/nycdb/nycdb/pull/234 (new table in existing `dobjobs` dataset)