### PR TITLE
update wow for new python version (heroku 22 stack)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=116f3f8f397bef3cc39c5cf59ad0d57fb8ad261c
+ARG WOW_REV=c91f9e05b904d0ee7777f945175362d49aec9a83
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
Updates WOW rev in in dockerfile to the [latest version](https://github.com/JustFixNYC/who-owns-what/commit/c91f9e05b904d0ee7777f945175362d49aec9a83), which includes upgrade to python version necessary for upgrading to Heroku stack 2022