### PR TITLE
update wow_rev for adding council to legacy addr search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install -e .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=8de95e871260ee6bd43fe94d4ad7422809a06c6c
+ARG WOW_REV=bc44ba8c52efda6b20d77943b8db8257deff5dba
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
Update the WOW version for addition of council district to legacy address search (https://github.com/JustFixNYC/who-owns-what/pull/728)