### PR TITLE
update for nycdb updates to package setup and psycopg version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
-FROM python:3.6 AS base
+FROM python:3.9 AS base
 
 RUN apt-get update && \
   apt-get install -y \
   unzip \
+  libpq5 \
   postgresql-client && \
   rm -rf /var/lib/apt/lists/*
 
-# The latest version of pip at the time of this writing, 20.3, results
-# in an infinite loop of "Requirement already satisfied" when
-# installing our dependencies, so we're forcibly downgrading to
-# the most recent version that works.
-RUN python -m pip install pip==20.2.4
+RUN python -m pip install pip==23.2
 
 COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=cacc0219517e557eeed61bc105278c0575e83ad0
+ARG NYCDB_REV=45bba9e42984be7cc8d9ed6f13d9d70172ab56aa
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.
@@ -25,7 +22,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && rm nycdb.zip \
   && mv nycdb-${NYCDB_REV} nycdb \
   && cd nycdb/src \
-  && pip install -e .
+  && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
 ARG WOW_REV=907eb121a6f41d277152067fe2d792a087bc0ce0
@@ -41,11 +38,11 @@ RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
 # it into our Python installation and manually installing its
 # dependencies, at least until we formally turn it into a
 # real Python package.
-RUN ln -s /who-owns-what/portfoliograph /usr/local/lib/python3.6/site-packages/portfoliograph && \
+RUN ln -s /who-owns-what/portfoliograph /usr/local/lib/python3.9/site-packages/portfoliograph && \
   pip install networkx==2.5.1 && pip install numpy==1.19.5
 
 # For now we also do the same process for OCA data prep.
-RUN ln -s /who-owns-what/ocaevictions /usr/local/lib/python3.6/site-packages/ocaevictions && \
+RUN ln -s /who-owns-what/ocaevictions /usr/local/lib/python3.9/site-packages/ocaevictions && \
   pip install sshtunnel==0.4.0
 
 ENV PYTHONUNBUFFERED yup

--- a/lib/dbhash.py
+++ b/lib/dbhash.py
@@ -52,6 +52,7 @@ class SqlDbHash(AbstractDbHash):
     PARAM_SUBST_STRINGS: Dict[str, str] = {
         "sqlite3": r"?",
         "psycopg2.extensions": r"%s",
+        "psycopg": r"%s",
     }
 
     def __init__(self, conn: Connection, table: str, autocommit: bool = True):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 certifi==2022.12.7
 chardet==3.0.4
 idna==2.8
-psycopg2==2.7.6.1
-requests==2.21.0
+psycopg2==2.8
+requests==2.31.0
 tqdm==4.28.1
 urllib3==1.26.5
 xlrd==1.2.0

--- a/scheduling.py
+++ b/scheduling.py
@@ -69,6 +69,7 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "dcp_housingdb": Schedule.EVERY_OTHER_DAY,
     "speculation_watch_list": Schedule.EVERY_OTHER_DAY,
     "hpd_affordable_production": Schedule.EVERY_OTHER_DAY,
+    "dof_tax_lien_sale_list": Schedule.EVERY_OTHER_DAY,
 }
 
 

--- a/tests/test_lastmod.py
+++ b/tests/test_lastmod.py
@@ -41,7 +41,7 @@ class TestLastmodInfo:
 
 
 class TestUrlModTracker:
-    def setup(self):
+    def setup_method(self):
         self.dbh = DictDbHash()
 
     def test_it_updates_lastmods(self, requests_mock):


### PR DESCRIPTION
This PR updates to the latest version of NYCDB. More than the usual updating of the commit hash and new datasets, there were a few additional changes required for the Dockerfile.

In https://github.com/nycdb/nycdb/pull/257 the python package setup files were changed - removing the `setup.py` and instead using `pyproject.toml`. Apparently without a setup.py you can't install in editable mode (`pip install -e .`), so that was removed, but isn't important. Also in that nycdb PR the new psycopg (3) replaces psycopg2, and this caused some issues and conflicts with packages, so required a few more changes - I've updated the dockerfile to use python 3.9, upgraded the pip version, and bumped the versions of a couple packages. And changing to python 3.9 required upgrading this repo's psycopg2 version, and that required a couple minor code changes.

With this PR we're adding a few new datasets, but most use the default annual schedule so don't appear in the code. They are:
* `dof_tax_lien_sale_list`
* `pluto_23v1`
* `vacate_orders`
* `mci_applications`

I've already created the new jobs on our digital ocean kubernetes, and once this is merged and published to dockerhub I'll trigger those to run for the first time. 