### PR TITLE
update nycdb commit hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=45bba9e42984be7cc8d9ed6f13d9d70172ab56aa
+ARG NYCDB_REV=21b5f71dadca0ae8a0d1de0b5c4e4de5b2e558a1
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
updating the nycdb version for this branch where I fixed an issue with our db inserts that was slowing everything down a ton. It's not merged into main yet, but I've tested it out locally with k8s-loader, and wanted to get this up before it does another round of super slow updates. 