### PR TITLE
update nycdb hash for testing revert to psycopg2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=21b5f71dadca0ae8a0d1de0b5c4e4de5b2e558a1
+ARG NYCDB_REV=31403d3648318f852c81bf96e98739499deb8ae7
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
Since the update to psycopg3 in nycdb (https://github.com/nycdb/nycdb/pull/257) we've been having some problems with the auto-updating. First it was an issue with the method of inserting rows of data which slowed everything way down so jobs were either taking forever or stalling out and breaking. That seems to have been fixed by using multi-row insert statements (https://github.com/nycdb/nycdb/pull/266), and now the jobs take the normal amount of time. 

However, there remains something weird going on when trying to run the new pluto (22v1, 23v1) datasets. they work fine with just nycdb locally, also work running k8s-loader jobs locally with a local db and a remote db, but when the exact same jobs run on kubernetes they just stall out after having created the table just before the rows are inserted. I can't think of what the issue is, but want to try reverting back to psycpg2 temporarily and try that. 