### PR TITLE
Revert "update nycdb hash for testing revert to psycopg2 (#133)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=31403d3648318f852c81bf96e98739499deb8ae7
+ARG NYCDB_REV=21b5f71dadca0ae8a0d1de0b5c4e4de5b2e558a1
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
Switching back to psycopg2 (#133) did not solve the issue of new pluto jobs failing, so I'm undoing that change. 

After doing some more digging, it appears that the new pluto jobs are failing because they are exceeding the memory limits for what's available to the kubernetes pods. I'm not sure why these new datasets are taking so much more memory, but for now I'm just going to run `pluto_22v1` and `pluto_23v1` jobs locally to update the remote nycdb instance, and then look more into nycdb code to optimize for memory usage and see how to increase memory limits on our kubernetes.