### PR TITLE
update nycdb version for new oca_metadata table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=fc7fa7a4bd1fb33a50fbc189992878761182ab13
+ARG NYCDB_REV=4d3ec9d90db0c378a8a35a53a96a0c23133f85fa
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
We have created a new table to add to the existing oca dataset of housing court records. This isn't directly in the raw data they provide, but records some important metadata about when records appear in OCA's extracts, which will help us to more accurately track the lagged reporting of cases that we know is an issue, as well as have a sense of the number of records they request us to delete (sealed records, etc.).

For more info see:
https://github.com/housing-data-coalition/oca/pull/10
https://github.com/nycdb/nycdb/pull/288