### PR TITLE
add 2 retry attempts on failure to template for all k8s jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ k8s-jobs/
 .env
 venv/
 .ssh/
+.DS_Store

--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -9,5 +9,5 @@ spec:
         spec:
           containers:
           - name: load-dataset
-          restartPolicy: Never
-      backoffLimit: 0
+          restartPolicy: OnFailure
+      backoffLimit: 2


### PR DESCRIPTION
We've been having some issues with the connection dropping during long running jobs. Because they run late at night, take a long time, and there is a sequence for them (wow table need to be built after others), it makes it hard to notice and manually rerun the jobs quickly enough before it's almost time for them to run again for the next day. This will be an even bigger problem once email alerts launch and we really need to have everything up-to-date for the updates. 

This PR adds to the k8s cron job yaml template so that all jobs will make 2 additional attempts at running if the job fails. 

I've already rebuilt and replace the jobs on our digital ocean k8s cluster. And there happens to be an unrelated issue with one of the jobs failing so I was able to confirm that it does the retries correctly. 