### PR TITLE
switch back to "Never" restartPolicy, keep backoffLimit

### DIFF
--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -9,5 +9,5 @@ spec:
         spec:
           containers:
           - name: load-dataset
-          restartPolicy: OnFailure
+          restartPolicy: Never
       backoffLimit: 2


### PR DESCRIPTION
After editing the k8s cron job template to add retries, it turns out that the `OnFailure` option has a weird issue that the pod creates automatically deleted after running so you can check the logs. But all that's really needed it the `BackoffLimit`, so the this PR changes back to `restartPolicy: Never` and that preserves the pods for all retries so we can inspect the logs. I've updated all the jobs on k8s and tested this out and it works. 