### PR TITLE
update nycdb, adding postgis and various new datasets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && \
   apt-get install -y \
   unzip \
   libpq5 \
-  postgresql-client && \
+  postgresql-client \
+  postgis && \
   rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install pip==23.2
@@ -13,7 +14,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=4d3ec9d90db0c378a8a35a53a96a0c23133f85fa
+ARG NYCDB_REV=5b182fc4cb5c68c652a54889c9ac04cf8b56d4ed
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,10 @@ services:
     links:
       - db
   db:
-    image: postgres:9.6
+    image: postgis/postgis:12-3.4
     environment:
       - POSTGRES_USER=nycdb
       - POSTGRES_DB=nycdb
       - POSTGRES_PASSWORD=nycdb
+    ports:
+      - 127.0.0.1:5432:5432

--- a/scheduling.py
+++ b/scheduling.py
@@ -70,6 +70,11 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "speculation_watch_list": Schedule.EVERY_OTHER_DAY,
     "hpd_affordable_production": Schedule.EVERY_OTHER_DAY,
     "dof_tax_lien_sale_list": Schedule.EVERY_OTHER_DAY,
+    "dob_certificate_occupancy": Schedule.EVERY_OTHER_DAY,
+    "dob_safety_violations": Schedule.EVERY_OTHER_DAY,
+    "hpd_hwo_charges": Schedule.DAILY_12AM,
+    "hpd_omo": Schedule.DAILY_12AM,
+    "dhs_daily_shelter_count": Schedule.DAILY_12AM,
 }
 
 

--- a/tests/sql/wow_2021_create_bldgs_table.sql
+++ b/tests/sql/wow_2021_create_bldgs_table.sql
@@ -57,8 +57,7 @@ complaints as (
             as complainttype,
             count(*) filter (where h.receiveddate > CURRENT_DATE - '3 YEARS'::INTERVAL) as countrecentcomplaints,
             count(*) counttotalcomplaints
-        from hpd_complaints h
-        left join hpd_complaint_problems using(complaintid)
+        from hpd_complaints_and_problems using(complaintid)
         group by bbl, complainttype
     ) subtable
     -- ----------

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -40,9 +40,14 @@ def run_dataset_specific_test_logic(conn, dataset):
             # Make sure the function defined by the dataset's SQL scripts exists.
             cur.execute("SELECT get_corporate_owner_info_for_regid(1)")
 
-
 @pytest.mark.parametrize("dataset", nycdb.dataset.datasets().keys())
 def test_load_dataset_works(test_db_env, dataset):
+    spatial_datasets = ["boundaries"]
+    if dataset in spatial_datasets:
+        with make_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS POSTGIS;")
+            conn.commit()
     subprocess.check_call(["python", "load_dataset.py", dataset], env=test_db_env)
 
     with make_conn() as conn:


### PR DESCRIPTION
update the version of nycdb to include a number of recent updates
* adds postgis and spatial datasets
  * https://github.com/nycdb/nycdb/pull/308
  * https://github.com/nycdb/nycdb/pull/313
  * https://github.com/nycdb/nycdb/pull/321
* removes deprecated `hpd_complaints` and `hpd_complaint_problems` tables 
* adds new datasets: 
  * `dob_certificate_occupancy`
  * `dob_safety_violations`
  * `hpd_hwo_charges`
  * `hpd_omo`
  * `dhs_daily_shelter_count`
  * `boundaries`