### PR TITLE
update nycdb version for test of switching to copy import method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=5b182fc4cb5c68c652a54889c9ac04cf8b56d4ed
+ARG NYCDB_REV=58c9caedeee3583987b5ba767fb34a44a4f9b5b0
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
There is a proposed change to nycdb to use the `copy` method for inserting data into the db (https://github.com/nycdb/nycdb/pull/328), and this appears to considerably speed up the process. it's still a work in progress, but I want to temporarily update the docker image to test this on kubernetes and see what impact there is on cpu usage since that continues to be an issue. 