### PR TITLE
add k8s cronjob resource requests values (mem, cpu)

### DIFF
--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -9,5 +9,9 @@ spec:
         spec:
           containers:
           - name: load-dataset
+            resources:
+              requests:
+                memory: "128Mi"
+                cpu: "1000m"
           restartPolicy: Never
       backoffLimit: 2


### PR DESCRIPTION
This edits the kubernetes cronjob template yaml definition to include default resource request limits for memory and cpu. With these resource request values kubernetes ensures that before the scheduled cronjob begins (pod created) there is at least this much memory and cpu available for the life of the job. In practice this means that it will delay the start of the job from the cronjob time (since we have a lot all scheduled for the same times) but we will avoid the problem of exceeding our resources and crashing. 

I've already recreated all the k8s job files and uploaded to the k8s cluster and things are working as intended

[sc-13183]