### PR TITLE
replicate dbhash url tracker for dataset update date tracker

### DIFF
--- a/dbtool.py
+++ b/dbtool.py
@@ -94,7 +94,7 @@ def shell(db_url: str):
 
 def list_lastmod(db_url: str, dataset_names: List[str]):
     with psycopg2.connect(db_url) as conn:
-        dbhash = load_dataset.get_dbhash(conn)
+        dbhash = load_dataset.get_url_dbhash(conn)
         for dataset in dataset_names:
             print(f"For the dataset {dataset}:")
             urls = load_dataset.get_urls_for_dataset(dataset)
@@ -110,7 +110,7 @@ def list_lastmod(db_url: str, dataset_names: List[str]):
 
 def reset_lastmod(db_url: str, dataset_names: List[str]):
     with psycopg2.connect(db_url) as conn:
-        dbhash = load_dataset.get_dbhash(conn)
+        dbhash = load_dataset.get_url_dbhash(conn)
         for dataset in dataset_names:
             print(f"For the dataset {dataset}:")
             urls = load_dataset.get_urls_for_dataset(dataset)

--- a/lib/dataset_tracker.py
+++ b/lib/dataset_tracker.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from .dbhash import AbstractDbHash
+
+
+class DatasetTracker:
+    dataset: str
+
+    def __init__(self, dataset: str, dbhash: AbstractDbHash):
+        self.dataset = dataset
+        self.dbhash = dbhash
+
+    def update_tracker(self) -> None:
+        self.dbhash.set_or_delete(self.dataset, datetime.now().isoformat())

--- a/lib/dataset_tracker.py
+++ b/lib/dataset_tracker.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+import pytz
+
 from .dbhash import AbstractDbHash
 
 
@@ -10,4 +12,5 @@ class DatasetTracker:
         self.dbhash = dbhash
 
     def update_tracker(self) -> None:
-        self.dbhash.set_or_delete(self.dataset, datetime.now().isoformat())
+        update_timestamp = datetime.now(pytz.timezone("America/New_York")).isoformat()
+        self.dbhash.set_or_delete(self.dataset, update_timestamp)

--- a/ocautil.py
+++ b/ocautil.py
@@ -77,11 +77,10 @@ def build(db_url: str, is_testing: bool = False):
         TableInfo(name=name, dataset=cosmetic_dataset_name) for name in OCA_TABLES
     ]
 
-    dataset_dbhash = get_dataset_dbhash(conn)
-    dataset_tracker = DatasetTracker(cosmetic_dataset_name, dataset_dbhash)
-
     with psycopg2.connect(db_url) as conn:
         install_db_extensions(conn)
+        dataset_dbhash = get_dataset_dbhash(conn)
+        dataset_tracker = DatasetTracker(cosmetic_dataset_name, dataset_dbhash)
         temp_schema = create_temp_schema_name(cosmetic_dataset_name)
         with create_and_enter_temporary_schema(conn, temp_schema):
             create_and_populate_oca_tables(conn, is_testing)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,3 +7,4 @@ python-dotenv
 requests-mock
 pyflakes==2.1.0
 black==20.8b1
+freezegun==1.5.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,3 +8,4 @@ requests-mock
 pyflakes==2.1.0
 black==20.8b1
 freezegun==1.5.1
+pytz==2024.1

--- a/signatureutil.py
+++ b/signatureutil.py
@@ -79,11 +79,10 @@ def build(db_url: str, is_testing: bool = False):
         TableInfo(name=name, dataset=cosmetic_dataset_name) for name in SIGNATURE_TABLES
     ]
 
-    dataset_dbhash = get_dataset_dbhash(conn)
-    dataset_tracker = DatasetTracker(cosmetic_dataset_name, dataset_dbhash)
-
     with psycopg2.connect(db_url) as conn:
         install_db_extensions(conn)
+        dataset_dbhash = get_dataset_dbhash(conn)
+        dataset_tracker = DatasetTracker(cosmetic_dataset_name, dataset_dbhash)
         temp_schema = create_temp_schema_name(cosmetic_dataset_name)
         with create_and_enter_temporary_schema(conn, temp_schema):
             create_and_populate_signature_tables(conn, is_testing)

--- a/tests/test_dataset_tracker.py
+++ b/tests/test_dataset_tracker.py
@@ -1,5 +1,6 @@
 import freezegun
 from datetime import datetime
+import pytz
 
 from lib.dataset_tracker import DatasetTracker
 from lib.dbhash import DictDbHash
@@ -15,5 +16,7 @@ class TestDatasetTracker:
             assert self.dbh.d == {}
 
             dt.update_tracker()
-            assert self.dbh.d == {"blah": datetime.now().isoformat()}
-
+            update_timestamp = datetime.now(
+                pytz.timezone("America/New_York")
+            ).isoformat()
+            assert self.dbh.d == {"blah": update_timestamp}

--- a/tests/test_dataset_tracker.py
+++ b/tests/test_dataset_tracker.py
@@ -1,0 +1,20 @@
+import pytest
+import freezegun
+from datetime import datetime
+
+from lib.dataset_tracker import DatasetTracker
+from lib.dbhash import DictDbHash
+
+
+class TestDatasetTracker:
+    def setup_method(self):
+        self.dbh = DictDbHash()
+
+    def test_it_updates_date(self):
+        with freezegun.freeze_time("2024-01-01"):
+            dt = DatasetTracker("blah", self.dbh)
+            assert self.dbh.d == {}
+
+            dt.update_tracker()
+            assert self.dbh.d == {"blah": datetime.now().isoformat()}
+

--- a/tests/test_dataset_tracker.py
+++ b/tests/test_dataset_tracker.py
@@ -1,4 +1,3 @@
-import pytest
 import freezegun
 from datetime import datetime
 

--- a/tests/test_dbtool.py
+++ b/tests/test_dbtool.py
@@ -49,7 +49,7 @@ def test_rowcounts_works(test_db_env, capsys):
 @contextlib.contextmanager
 def load_dbhash():
     with psycopg2.connect(DATABASE_URL) as conn:
-        dbhash = load_dataset.get_dbhash(conn)
+        dbhash = load_dataset.get_url_dbhash(conn)
         yield dbhash
 
 

--- a/wowutil.py
+++ b/wowutil.py
@@ -140,11 +140,10 @@ def build(db_url: str):
         for name in parse_created_tables_in_dir(WOW_SQL_DIR, WOW_SCRIPTS)
     ]
 
-    dataset_dbhash = get_dataset_dbhash(conn)
-    dataset_tracker = DatasetTracker(cosmetic_dataset_name, dataset_dbhash)
-
     with psycopg2.connect(db_url) as conn:
         install_db_extensions(conn)
+        dataset_dbhash = get_dataset_dbhash(conn)
+        dataset_tracker = DatasetTracker(cosmetic_dataset_name, dataset_dbhash)
         temp_schema = create_temp_schema_name(cosmetic_dataset_name)
         with create_and_enter_temporary_schema(conn, temp_schema):
             run_wow_sql(conn)

--- a/wowutil.py
+++ b/wowutil.py
@@ -27,7 +27,7 @@ from algoliasearch.search_client import SearchClient
 from load_dataset import (
     create_temp_schema_name,
     create_and_enter_temporary_schema,
-    get_dbhash,
+    get_url_dbhash,
     get_urls_for_dataset,
     save_and_reapply_permissions,
     ensure_schema_exists,
@@ -73,7 +73,7 @@ def populate_portfolios_table(conn):
 
 
 def get_hpd_last_updated_date(conn):
-    dbhash = get_dbhash(conn)
+    dbhash = get_url_dbhash(conn)
     modtracker = UrlModTracker(get_urls_for_dataset("hpd_registrations"), dbhash)
     hpd_regs_last_updated = modtracker.dbhash.get(f"last_modified:{modtracker.urls[0]}")
 


### PR DESCRIPTION
We already have a setup for creating a table that tracks metadata from the URLs of datasets we're downloading to prevent updating when nothing has changed from the source. It works with the `dbhash` class to create the table (in a `nycdb_k8s_loader` schema) and manage changes to it, it follows a simple structure with `key` and `value` string columns. And then another class (for urls it's `lastmod` and for this new one it's `dataset_tracker`) to do the updating of those records. For the `key` we're using the dataset name, so for nycdb that's just one for all tables it covers (eg. `acris` for all the acris tables). And for the `value` it's a timestamp in local nyc timezone but stored as a string in standard iso format. Because the setup was all built out already for the two text columns for now I've just kept that and we can really easily just cast the text to date when querying it and that seemed easier for now rather than changing things a bunch to use a date column.

Once we have this new `dataset_tracker` table added to the db we can add an api endpoint to wow for checking the date each dataset was last updated on our db. 

[sc-14791]