### PR TITLE
use NYC local time in k8s cron job scheduling

### DIFF
--- a/k8s-job-template.yml
+++ b/k8s-job-template.yml
@@ -15,3 +15,4 @@ spec:
                 cpu: "1000m"
           restartPolicy: Never
       backoffLimit: 2
+  timeZone: "America/New_York"

--- a/scheduling.py
+++ b/scheduling.py
@@ -5,18 +5,19 @@ import nycdb.dataset
 
 class Schedule(Enum):
     """
-    Abstracts away scheduling frequency from the particular
-    scheduling technology being used (AWS, k8s, etc).
+    Abstracts away scheduling frequency from the particular scheduling
+    technology being used (AWS, k8s, etc). All times are in NYC local time, so
+    adjust with daylight savings.
     """
 
-    # Daily at around midnight EST.
-    DAILY_12AM = "0 4 * * ?"
+    # Daily at around midnight.
+    DAILY_12AM = "0 24 * * ?"
 
-    # Daily at around 7am EST.
-    DAILY_7AM = "0 11 * * ?"
+    # Daily at around 7am.
+    DAILY_7AM = "0 7 * * ?"
 
-    # Every other day around midnight EST.
-    EVERY_OTHER_DAY = "0 4 */2 * ?"
+    # Every other day around midnight.
+    EVERY_OTHER_DAY = "0 24 */2 * ?"
 
     # Once per year.
     YEARLY = "@yearly"


### PR DESCRIPTION
Specify the timezone in our k8s cron job definitions so that it's easier to read on dashboard, in scheduling script, and we also don't have to worry about things shifting around with daylight savings time

[sc-15773]