### PR TITLE
change nycdb version to debug file download issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=23bf81975d7a7c3e7cd16d168e42bf6339b4d08b
+ARG NYCDB_REV=559ac04951513288e762e4a7a8f3fb3cc1f1364b
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=559ac04951513288e762e4a7a8f3fb3cc1f1364b
+ARG NYCDB_REV=cc2ce6ec900cdd39ce2d8fbbc02e0348778734c9
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
Something has been going wrong with NYCDB file downloads, and so this changes the nycdb version to a branch with some debugging added to it t help us find the issue in production since it's hard to reproduce the error