### PR TITLE
update nycdb for testing acris job split

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=cc2ce6ec900cdd39ce2d8fbbc02e0348778734c9
+ARG NYCDB_REV=bb87ccf8a3e2fb651207634a441917c30f2bee06
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/scheduling.py
+++ b/scheduling.py
@@ -78,6 +78,7 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "dof_sales": Schedule.ODD_DAYS_11PM,
     "pad": Schedule.ODD_DAYS_11PM,
     "acris": Schedule.EVEN_DAYS_11PM,
+    "acris_real": Schedule.EVEN_DAYS_11PM,
     "pluto_latest": Schedule.ODD_DAYS_11PM,
     "dcp_housingdb": Schedule.ODD_DAYS_11PM,
     "speculation_watch_list": Schedule.ODD_DAYS_11PM,


### PR DESCRIPTION
the ACRIS job is often causing a strain on k8s resources because of the size of the jobs - with so many tables and many of them are 20+ million rows. On nycdb I've made a branch that adds partial versions of the acris dataset (while preserving the original) with just real property, personal property, and the smaller common lookup tables. Then we can test out the split jobs on k8s to see if this helps, of it it's just the size of the single tables that's the problem.