### PR TITLE
update nycdb for dob now CofO data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=bb87ccf8a3e2fb651207634a441917c30f2bee06
+ARG NYCDB_REV=03e26a81a302b0525d6a8f0bfcf31f19f8b3ca53
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/scheduling.py
+++ b/scheduling.py
@@ -78,7 +78,6 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "dof_sales": Schedule.ODD_DAYS_11PM,
     "pad": Schedule.ODD_DAYS_11PM,
     "acris": Schedule.EVEN_DAYS_11PM,
-    "acris_real": Schedule.EVEN_DAYS_11PM,
     "pluto_latest": Schedule.ODD_DAYS_11PM,
     "dcp_housingdb": Schedule.ODD_DAYS_11PM,
     "speculation_watch_list": Schedule.ODD_DAYS_11PM,


### PR DESCRIPTION
Update NYCDB version to include dob now CofO data from: https://github.com/nycdb/nycdb/pull/371

[sc-16215]