### PR TITLE
update nycdb to add executed_evictions dataset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=a9872f3ee51281fe87901cf49612cfde3812cc40
+ARG NYCDB_REV=850ac4c46e7ca880611a208ee5a86ce01e2f60b7
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/scheduling.py
+++ b/scheduling.py
@@ -93,6 +93,7 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "dos_active_corporations": Schedule.ODD_DAYS_11PM,
     "dof_property_valuation_and_assessments": Schedule.ODD_DAYS_11PM,
     "hpd_litigations": Schedule.DAILY_11PM,
+    "executed_evictions": Schedule.DAILY_11PM,
 }
 
 


### PR DESCRIPTION
Adds `executed_evictions` dataset, see https://github.com/nycdb/nycdb/pull/383

[sc-16250]
