### PR TITLE
use backup schema for wow tables

### DIFF
--- a/wowutil.py
+++ b/wowutil.py
@@ -51,6 +51,8 @@ WOW_YML = yaml.load((WOW_DIR / "who-owns-what.yml").read_text(), Loader=yaml.Ful
 
 WOW_SCRIPTS: List[str] = WOW_YML["sql"]
 
+BACKUP_SCHEMA = "backup"
+
 
 def run_wow_sql(conn):
     with conn.cursor() as cur:
@@ -158,7 +160,8 @@ def build(db_url: str):
             populate_portfolios_table(conn)
             ensure_schema_exists(conn, WOW_SCHEMA)
             with save_and_reapply_permissions(conn, tables, WOW_SCHEMA):
-                drop_tables_if_they_exist(conn, tables, WOW_SCHEMA)
+                drop_tables_if_they_exist(conn, tables, BACKUP_SCHEMA)
+                change_table_schemas(conn, tables, WOW_SCHEMA, BACKUP_SCHEMA)
                 change_table_schemas(conn, tables, temp_schema, WOW_SCHEMA)
 
         # The WoW tables are now ready, but the functions defined by WoW were

--- a/wowutil.py
+++ b/wowutil.py
@@ -160,6 +160,7 @@ def build(db_url: str):
             populate_portfolios_table(conn)
             ensure_schema_exists(conn, WOW_SCHEMA)
             with save_and_reapply_permissions(conn, tables, WOW_SCHEMA):
+                ensure_schema_exists(conn, BACKUP_SCHEMA)
                 drop_tables_if_they_exist(conn, tables, BACKUP_SCHEMA)
                 change_table_schemas(conn, tables, WOW_SCHEMA, BACKUP_SCHEMA)
                 change_table_schemas(conn, tables, temp_schema, WOW_SCHEMA)


### PR DESCRIPTION
For the our WOW tables created via nycdb-k8s-loader, there has always been a
brief period when the tables are recreated that they are inaccessible causing
"table not found" errors on our tools. As a solution to this we are creating
a new schema `backup` where we will move all the wow tables before moving the
new versions from their temporary schema to the `wow` schema. This way we are
never deleting the only copy of wow tables - there will always be another
copy in the `backup` schema. So we'll just change our wow-role search path to
include backup and so if it doesn't find the tables in `wow` it will find
them in `backup` until the new versions are ready again in `wow`

Once we confirm that this solves our problem with the downtime for wow tables used in wow apis, we can consider doing the same approach for other jobs. So for now I've only done this for the `wow` job, not the nycdb or others, but we could do the same for those if we want. If we do expand the use of it though I think we should add a step to delete the backup tables after the new ones are ready, so we aren't permanently keeping duplicates of every table.

I've tested this out on a temporary clone of our nycdb database and it seems to be working just fine. 

[Commands to set up `backup` schema and updating permissions](https://github.com/JustFixNYC/tenants2-security/blob/main/nycdb-database/backup-schema.sql)

[sc-16234]