### PR TITLE
update nycdb for pluto_latest_districts, handle missing nycdb schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=69b088103c309dadfca0fffc69cff03344e2ee3c
+ARG NYCDB_REV=a212291498e35c7d42ebcb83374d0a6e635cc167
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=1cdac9238491ed6f313987811bc69a2857698572
+ARG WOW_REV=ac1c7ebb20e7e556f12b19ca1871cea63f3dcdfd
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=ac1c7ebb20e7e556f12b19ca1871cea63f3dcdfd
+ARG WOW_REV=1cdac9238491ed6f313987811bc69a2857698572
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -112,6 +112,8 @@ def get_tables_for_dataset(dataset: str) -> List[TableInfo]:
 
 
 def get_urls_for_dataset(dataset: str) -> List[str]:
+    if "files" not in nycdb.dataset.datasets()[dataset]:
+        return []
     return [fileinfo["url"] for fileinfo in nycdb.dataset.datasets()[dataset]["files"]]
 
 

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -92,7 +92,8 @@ def get_temp_schemas(conn, dataset: str) -> List[str]:
 def get_dataset_tables() -> List[TableInfo]:
     result: List[TableInfo] = []
     for dataset_name, info in nycdb.dataset.datasets().items():
-        for schema in list_wrap(info["schema"]):
+        schemas = list_wrap(info["schema"]) if "schema" in info else []
+        for schema in schemas:
             result.append(TableInfo(name=schema["table_name"], dataset=dataset_name))
         result.extend(
             [

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -49,6 +49,14 @@ def test_load_dataset_works(test_db_env, dataset):
             with conn.cursor() as cur:
                 cur.execute("CREATE EXTENSION IF NOT EXISTS POSTGIS;")
             conn.commit()
+    
+    if dataset == "pluto_latest_districts":
+        subprocess.check_call(["python", "load_dataset.py", "pluto_latest"], env=test_db_env)
+        subprocess.check_call(["python", "load_dataset.py", "boundaries"], env=test_db_env)
+    elif dataset == "pluto_latest_districts_25a":
+        subprocess.check_call(["python", "load_dataset.py", "pluto_latest"], env=test_db_env)
+        subprocess.check_call(["python", "load_dataset.py", "boundaries_25a"], env=test_db_env)
+
     subprocess.check_call(["python", "load_dataset.py", dataset], env=test_db_env)
 
     with make_conn() as conn:

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -49,13 +49,21 @@ def test_load_dataset_works(test_db_env, dataset):
             with conn.cursor() as cur:
                 cur.execute("CREATE EXTENSION IF NOT EXISTS POSTGIS;")
             conn.commit()
-    
+
     if dataset == "pluto_latest_districts":
-        subprocess.check_call(["python", "load_dataset.py", "pluto_latest"], env=test_db_env)
-        subprocess.check_call(["python", "load_dataset.py", "boundaries"], env=test_db_env)
+        subprocess.check_call(
+            ["python", "load_dataset.py", "pluto_latest"], env=test_db_env
+        )
+        subprocess.check_call(
+            ["python", "load_dataset.py", "boundaries"], env=test_db_env
+        )
     elif dataset == "pluto_latest_districts_25a":
-        subprocess.check_call(["python", "load_dataset.py", "pluto_latest"], env=test_db_env)
-        subprocess.check_call(["python", "load_dataset.py", "boundaries_25a"], env=test_db_env)
+        subprocess.check_call(
+            ["python", "load_dataset.py", "pluto_latest"], env=test_db_env
+        )
+        subprocess.check_call(
+            ["python", "load_dataset.py", "boundaries_25a"], env=test_db_env
+        )
 
     subprocess.check_call(["python", "load_dataset.py", dataset], env=test_db_env)
 


### PR DESCRIPTION
updates nycdb for this yet-to-be-merged PR https://github.com/nycdb/nycdb/pull/386 which adds `pluto_latest_districts` and `pluto_latests_districts_25a`. There are still some changes that will need to be made on the nycdb side to make this dataset without source data pattern work well generally, but for now it's working to get it up in the DB and allow for the wow dataset to depend on this new nycdb dataset.