### PR TITLE
don't skip job for no-download datasets

### DIFF
--- a/load_dataset.py
+++ b/load_dataset.py
@@ -349,7 +349,11 @@ def load_dataset(
     dataset_tracker = DatasetTracker(dataset, dataset_dbhash)
 
     check_urls = (not config.use_test_data) or force_check_urls
-    if check_urls and not modtracker.did_any_urls_change():
+    if (
+        check_urls
+        and not modtracker.did_any_urls_change()
+        and dataset not in ["pluto_latest_districts", "pluto_latest_districts_25a"]
+    ):
         slack.sendmsg(
             f"The dataset `{dataset}` has not changed since we last retrieved it."
         )

--- a/load_dataset.py
+++ b/load_dataset.py
@@ -349,11 +349,7 @@ def load_dataset(
     dataset_tracker = DatasetTracker(dataset, dataset_dbhash)
 
     check_urls = (not config.use_test_data) or force_check_urls
-    if (
-        check_urls
-        and not modtracker.did_any_urls_change()
-        and dataset not in ["pluto_latest_districts", "pluto_latest_districts_25a"]
-    ):
+    if check_urls and not modtracker.did_any_urls_change() and ds.files:
         slack.sendmsg(
             f"The dataset `{dataset}` has not changed since we last retrieved it."
         )


### PR DESCRIPTION
For the new datasets `pluto_latest_districts` and `pluto_latest_districts_25a` there are no download files and so it's skipping builds since it can't find the last changed url metadata. This needs a proper fix but for now just need to get it working, so will return to address this in a better way soon