### PR TITLE
update wow version for adding census tracts to area alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=085adb996c08dba7b475a422597633edd1bd52f9
+ARG WOW_REV=5bc0328a7916e0bfbd72c7f1bacb0c7d0e37308e
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
updates WOW version for addition of census tracts to the possible area for area alerts

companion PRs: https://github.com/JustFixNYC/who-owns-what/pull/1012 and https://github.com/JustFixNYC/auth-provider/pull/80