### PR TITLE
update url for geosupport download in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ RUN apt-get update && \
 # Setup geosupport for standardizing addresses for wow
 # check the latest version here https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gdelx.page
 # make sure this gets updated regularly, and matches the version in who-owns-what
-ENV RELEASE=23c
-ENV MAJOR=23
-ENV MINOR=3
+ENV RELEASE=25b
+ENV MAJOR=25
+ENV MINOR=2
 ENV PATCH=0
 WORKDIR /geosupport
 
-RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}.zip; \
+RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}.${MINOR}.zip; \
     echo ${FILE_NAME}; \
-    curl -O https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/$FILE_NAME; \
+    curl -O https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/geosupport/$FILE_NAME; \
     unzip *.zip; \
     rm *.zip;
 


### PR DESCRIPTION
A new version of [Geosupport](https://www.nyc.gov/content/planning/pages/resources/geocoding/geosupport-desktop-edition) has been released, 25a, and this updates the dockerfile for the new download file. This also solves a confusing build error we were getting suddenly on CI. It's good to keep this updated regularly so that it keeps pace with the version of PLUTO we get in `pluto_latest`.