### PR TITLE
update wow for CofO bbl fix for GCE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=8245702fe24f1ea83ea8ddbccc2e71ecc239a414
+ARG WOW_REV=4ab03fdb142fedcca80d877a785374fc454956fa
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
Updates WOW version for change to GCE SQL that updates no longer existing BBLs with current BBLs for those BINs in the historic CofO records see https://github.com/JustFixNYC/who-owns-what/pull/1028