### PR TITLE
update nycdb for zipcodes dedupe and districts table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=a212291498e35c7d42ebcb83374d0a6e635cc167
+ARG NYCDB_REV=ad0366b98b2c20b1b9a49b91e3edcced74146645
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
Updates NYCDB version to include recent PRs:
- remove duplicate rows for zipcodes by joining multiple areas of the same zipcode into a single multipolygon geom and only one row per zipcode https://github.com/nycdb/nycdb/pull/388
- add `pluto_latest_districts` (and 25a version), which was previously only on a branch but now is improved and merged into main https://github.com/nycdb/nycdb/pull/386

I haven't added the new `pluto_latest_districts` datasets to the schedule or k8s cluster since we don't yet have a way to know when the updates are required. For now we can just run manually when pluto_latest updates, but later we might consider added to the update/change tracking system for these datasets without source data to instead check the update dates of the dependency datasets, so that the dataset will only be recreated when with pluto or the boundaries dataset updtesupdates.