### PR TITLE
update wow version for bldg alert data in wow_indicators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=e9add26a728a3cb135fad7257de6d8558a0dc0a5
+ARG WOW_REV=0f4d9fa385553fe5753994714c95fcc955165a81
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \


### PR DESCRIPTION
Update commit hash once wow is merged into main

related PRs:
* https://github.com/JustFixNYC/who-owns-what/pull/1033
* https://github.com/JustFixNYC/auth-provider/pull/101