### PR TITLE
update nycdb for dob_now_jobs schema change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=ae901623eca22a4e843b9a8f0c754409e4c40e06
+ARG NYCDB_REV=c8e09afa17c6f6dc822faf43408cd00dc928fbed
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
Adds two new columns to DOB NOW Jobs schema. see https://github.com/nycdb/nycdb/pull/391

[sc-16603]