### PR TITLE
update nycdb for pluto 25v2_1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=c8e09afa17c6f6dc822faf43408cd00dc928fbed
+ARG NYCDB_REV=070fdcf985d2fd51bddd2162d066f130f86dbc41
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
updates nycdb version for new dataset for pluto version 25v2_1 (see https://github.com/nycdb/nycdb/pull/392)

[sc-16574]