### PR TITLE
Wow update version & keep landlords table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=dcff4c1ea42d380e5c98f0b62386230c82a7f5a1
+ARG WOW_REV=425379da16ab9f2ea694d562673fb4baee51a817
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/wowutil.py
+++ b/wowutil.py
@@ -53,6 +53,8 @@ WOW_PRE_SCRIPTS: List[str] = WOW_YML["wow_pre_sql"]
 WOW_POST_SCRIPTS: List[str] = WOW_YML["wow_post_sql"]
 WOW_ALL_SCRIPTS = WOW_PRE_SCRIPTS + WOW_POST_SCRIPTS
 
+EXTRA_TABLES_TO_PRESERVE = ["landlords_with_connections"]
+
 
 def run_wow_sql(conn, scripts: List[str]):
     with conn.cursor() as cur:
@@ -147,6 +149,7 @@ def build(db_url: str):
     tables = [
         TableInfo(name=name, dataset=cosmetic_dataset_name)
         for name in parse_created_tables_in_dir(WOW_SQL_DIR, WOW_ALL_SCRIPTS)
+        + EXTRA_TABLES_TO_PRESERVE
     ]
 
     with psycopg2.connect(db_url) as conn:


### PR DESCRIPTION
This updates the wow version to get fix for excluding records with NULL bbl (https://github.com/JustFixNYC/who-owns-what/pull/1052) and also edits the wow job to allow us to keep intermediate tables after the job completes. Sometimes it's helpful to have the landlords table with all the matched connections before the network/pruning step, so I've kept the `wow.landlords_with_connections` table