### PR TITLE
Temp hpd reg fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=a53e277858aa66c2f39703d9f04f5f88c829feb0
+ARG NYCDB_REV=333892159aa3e33b04efce4bc90db733d6995ac0
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=bec4413f3335cea56cde11daef2c0e5a02a5c9f4
+ARG NYCDB_REV=a53e277858aa66c2f39703d9f04f5f88c829feb0
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=070fdcf985d2fd51bddd2162d066f130f86dbc41
+ARG NYCDB_REV=bec4413f3335cea56cde11daef2c0e5a02a5c9f4
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
update nycdb version for further temp changes to hpd registrations. Fix date typecast to accommodate different date format in archive version of registrations, and also use archived version of hpd contacts.