### PR TITLE
re-add gce_eligibility table for gce job, update some scheduling

### DIFF
--- a/goodcauseutil.py
+++ b/goodcauseutil.py
@@ -34,7 +34,7 @@ from wowutil import WOW_SQL_DIR, WOW_YML, install_db_extensions
 
 WOW_SCHEMA = "wow"
 
-GOOD_CAUSE_TABLES: List[str] = ["gce_screener"]
+GOOD_CAUSE_TABLES: List[str] = ["gce_screener", "gce_eligibility"]
 
 
 def create_and_populate_good_cause_tables(conn, is_testing: bool = False):

--- a/scheduling.py
+++ b/scheduling.py
@@ -86,7 +86,7 @@ DATASET_SCHEDULES: Dict[str, Schedule] = {
     "speculation_watch_list": Schedule.ODD_DAYS_11PM,
     "hpd_affordable_production": Schedule.ODD_DAYS_11PM,
     "dof_tax_lien_sale_list": Schedule.ODD_DAYS_11PM,
-    "dob_certificate_occupancy": Schedule.ODD_DAYS_11PM,
+    "dob_certificate_occupancy": Schedule.DAILY_11PM,
     "dob_safety_violations": Schedule.ODD_DAYS_11PM,
     "hpd_charges": Schedule.DAILY_11PM,
     "dhs_daily_shelter_count": Schedule.DAILY_11PM,


### PR DESCRIPTION
We previously excluded the `gce_eligibility` table from our good_cause_eviction job, but we're good to add that back in now. also change the CofO job to be daily instead of every-other-day