### PR TITLE
update nycdb and wow for postgres 14 typing updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=070fdcf985d2fd51bddd2162d066f130f86dbc41
+ARG NYCDB_REV=dc43e6ff2a1bea3b81fb6423227d993c480759d9
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.
@@ -47,7 +47,7 @@ RUN curl -L ${NYCDB_REPO}/archive/${NYCDB_REV}.zip > nycdb.zip \
   && pip install .
 
 ARG WOW_REPO=https://github.com/justFixNYC/who-owns-what
-ARG WOW_REV=fec1247a30ec6373a4fa4c4d386ff1ea386b21ef
+ARG WOW_REV=7b17b1fc041e997bd13e38bdfc2506bfd67f8b79
 RUN curl -L ${WOW_REPO}/archive/${WOW_REV}.zip > wow.zip \
   && unzip wow.zip \
   && rm wow.zip \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     links:
       - db
   db:
-    image: postgis/postgis:12-3.4
+    image: postgis/postgis:14-3.5
     environment:
       - POSTGRES_USER=nycdb
       - POSTGRES_DB=nycdb


### PR DESCRIPTION
We are upgrading our wow/nycdb DB on AWS from postgres 13 to 14, and there are some breaking changes to array type definitions for array functions, so we need to update the custom functions for the new types: anyarray -> anycompatiblearray. (and also change from `anyelement` to `anycompatiable`

https://github.com/JustFixNYC/who-owns-what/pull/1056

https://github.com/nycdb/nycdb/pull/394

I'll push this to main, but then test this out first on our clone of the DB before doing it on the prod version