### PR TITLE
update nycdb for dob c of o fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=22ad7dad2c0ffc18e5c9452f982b837aa4329d26
+ARG NYCDB_REV=2ffc92167662ed9174a354250f3af13e9599beb4
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
the layout of theDOB NOW CofO open data table changed, and this updates nycdb for the fix that adjusts the schema. 

This is still a commit on the postgres-upgrade branch of NYCDB, since I still want to upgrade the DB a couple major versionf of postgres and there may be other changes necessary

https://github.com/nycdb/nycdb/pull/395