### PR TITLE
update nycdb for new columns in pluto_latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY requirements.txt /
 RUN pip install -r requirements.txt
 
 ARG NYCDB_REPO=https://github.com/nycdb/nycdb
-ARG NYCDB_REV=4285f846bced1ade2274289a41d60686bafcdcc2
+ARG NYCDB_REV=833cf305545f936d7db57654a30552b52d4ee6a7
 # We need to retrieve the source directly from the repository
 # because we need access to the test data, which isn't part of
 # the pypi distribution.


### PR DESCRIPTION
New columns related to FAR and MIH were added to pluto_latest, so this updates our nycdb version for the schema fix in https://github.com/nycdb/nycdb/pull/407